### PR TITLE
allow a "rust" annotation on example code blocks

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1,6 +1,6 @@
 [root]
 name = "cargo-readme"
-version = "1.1.0"
+version = "1.2.0"
 dependencies = [
  "clap 2.22.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/src/doc.rs
+++ b/src/doc.rs
@@ -71,7 +71,7 @@ fn extract<T: Read>(source: &mut T, indent_headings: bool) -> Vec<String> {
     let reader = BufReader::new(source);
 
     // Is this code block rust?
-    let re_code_rust = Regex::new(r"^//! ```(no_run|ignore|should_panic)?$").unwrap();
+    let re_code_rust = Regex::new(r"^//! ```(rust,?)?(no_run|ignore|should_panic)?(,rust)?$").unwrap();
     // Is this code block a language other than rust?
     let re_code_other = Regex::new(r"//! ```\w+").unwrap();
 


### PR DESCRIPTION
Fixes https://github.com/livioribeiro/cargo-readme/issues/10.

I'm not sure this is the cleanest fix, but it seemed like the quickest way to fix that issue. It might be cleaner to parse out the list of annotations and check them one by one against the allowed list, though? For example, the regex as written allows

    //! ```rust,rust

and also

    //! ```rustrust

but not

    //! ```rust,rust,rust