### PR TITLE
Default to cargo's default path for lib projects

### DIFF
--- a/src/cargo_info.rs
+++ b/src/cargo_info.rs
@@ -6,6 +6,8 @@ use std::path::Path;
 
 use toml;
 
+pub const DEFAULT_LIB: &'static str = "src/lib.rs";
+
 /// Cargo.toml crate information
 #[derive(Clone, Deserialize)]
 pub struct Cargo {
@@ -24,7 +26,16 @@ pub struct CargoPackage {
 /// Cargo.toml crate lib information
 #[derive(Clone, Deserialize)]
 pub struct CargoLib {
-    pub path: String,
+    pub path: Option<String>,
+}
+
+impl CargoLib {
+    pub fn path_or_default(&self) -> &str {
+        self.path
+            .as_ref()
+            .map(|p| p.as_ref())
+            .unwrap_or(DEFAULT_LIB)
+    }
 }
 
 /// Try to get crate name and license from Cargo.toml


### PR DESCRIPTION
So that it's not necessary to specify a path in projects that have a [lib]
section for other reasons.


I could reduce the code churn a bit by setting the path in the CargoLib struct to the default, but that felt like it might be lying a bit. I'm happy to switch to that if you'd prefer.