### PR TITLE
Add crate *version* to a template generator

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ cargo install cargo-readme
 
 As you write documentation, you often have to show examples of how to use your software. But
 how do you make sure your examples are all working properly? That we didn't forget to update
-them after a braking change and left our (possibly new) users with errors they will have to
+them after a breaking change and left our (possibly new) users with errors they will have to
 figure out by themselves?
 
 With `cargo-readme`, you just write the rustdoc, run the tests, and then run:
@@ -105,7 +105,7 @@ content:
 
 {{readme}}
 
-Some additional info here
+Some additional info here, like: "current version is {{version}}"
 
 License: {{license}}
 ```

--- a/README.md
+++ b/README.md
@@ -105,7 +105,9 @@ content:
 
 {{readme}}
 
-Some additional info here, like: "current version is {{version}}"
+Current version: {{version}}
+
+Some additional info here
 
 License: {{license}}
 ```
@@ -116,6 +118,8 @@ The output will look like this
 [![Build Status](__badge_image__)](__badge_url__)
 
 # my_crate
+
+Current version: 3.0.0
 
 This is my awesome crate
 

--- a/src/config/manifest.rs
+++ b/src/config/manifest.rs
@@ -36,6 +36,7 @@ pub struct Manifest {
     pub lib: Option<ManifestLib>,
     pub bin: Vec<ManifestLib>,
     pub badges: Vec<String>,
+    pub version: String,
 }
 
 impl Manifest {
@@ -49,7 +50,8 @@ impl Manifest {
             }).unwrap_or_default(),
             badges: cargo_toml.badges
                 .map(|b| process_badges(b))
-                .unwrap_or_default()
+                .unwrap_or_default(),
+            version: cargo_toml.package.version,
         }
     }
 }
@@ -103,6 +105,7 @@ struct CargoToml {
 struct CargoTomlPackage {
     pub name: String,
     pub license: Option<String>,
+    pub version: String,
 }
 
 /// Cargo.toml crate lib information

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -101,7 +101,9 @@
 //!
 //! {{readme}}
 //!
-//! Some additional info here, like: "current version is {{version}}"
+//! Current version: {{version}}
+//!
+//! Some additional info here
 //!
 //! License: {{license}}
 //! ```
@@ -112,6 +114,8 @@
 //! [![Build Status](__badge_image__)](__badge_url__)
 //!
 //! # my_crate
+//!
+//! Current version: 3.0.0
 //!
 //! This is my awesome crate
 //!

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,7 +13,7 @@
 //!
 //! As you write documentation, you often have to show examples of how to use your software. But
 //! how do you make sure your examples are all working properly? That we didn't forget to update
-//! them after a braking change and left our (possibly new) users with errors they will have to
+//! them after a breaking change and left our (possibly new) users with errors they will have to
 //! figure out by themselves?
 //!
 //! With `cargo-readme`, you just write the rustdoc, run the tests, and then run:
@@ -101,7 +101,7 @@
 //!
 //! {{readme}}
 //!
-//! Some additional info here
+//! Some additional info here, like: "current version is {{version}}"
 //!
 //! License: {{license}}
 //! ```

--- a/src/readme/template.rs
+++ b/src/readme/template.rs
@@ -18,8 +18,10 @@ pub fn render(
 
     let license: Option<&str> = cargo.license.as_ref().map(AsRef::as_ref);
 
+    let version: &str = cargo.version.as_ref();
+
     if let Some(template) = template {
-        process_template(template, readme, title, badges, license)
+        process_template(template, readme, title, badges, license, version)
     } else {
         process_string(readme, title, badges, license, add_title, add_badges, add_license)
     }
@@ -32,12 +34,14 @@ pub fn render(
 /// - `{{crate}}` crate name defined in `Cargo.toml`
 /// - `{{badges}}` badges defined in `Cargo.toml`
 /// - `{{license}}` license defined in `Cargo.toml`
+/// - `{{version}}` version defined in `Cargo.toml`
 fn process_template(
     mut template: String,
     readme: String,
     title: &str,
     badges: &[&str],
     license: Option<&str>,
+    version: &str,
 ) -> Result<String, String> {
 
     template = template.trim_right_matches("\n").to_owned();
@@ -69,6 +73,8 @@ fn process_template(
             );
         }
     }
+
+    template = template.replace("{{version}}", version);
 
     let result = template.replace("{{readme}}", &readme);
     Ok(result)
@@ -133,63 +139,71 @@ mod tests {
     const TEMPLATE_WITH_TITLE: &str = "# {{crate}}\n\n{{readme}}";
     const TEMPLATE_WITH_BADGES: &str = "{{badges}}\n\n{{readme}}";
     const TEMPLATE_WITH_LICENSE: &str = "{{readme}}\n\n{{license}}";
-    const TEMPLATE_FULL: &str = "{{badges}}\n\n# {{crate}}\n\n{{readme}}\n\n{{license}}";
+    const TEMPLATE_WITH_VERSION: &str = "{{readme}}\n\n{{version}}";
+    const TEMPLATE_FULL: &str = "{{badges}}\n\n# {{crate}}\n\n{{readme}}\n\n{{license}}\n\n{{version}}";
 
     // process template
     #[test]
     fn template_without_readme_should_fail() {
-        let result = super::process_template(String::new(), String::new(), "", &[], None);
+        let result = super::process_template(String::new(), String::new(), "", &[], None, "");
         assert!(result.is_err());
         assert_eq!("Missing `{{readme}}` in template", result.unwrap_err());
     }
 
     #[test]
     fn template_with_badge_tag_but_missing_badges_should_fail() {
-        let result = super::process_template(TEMPLATE_WITH_BADGES.to_owned(), String::new(), "", &[], None);
+        let result = super::process_template(TEMPLATE_WITH_BADGES.to_owned(), String::new(), "", &[], None, "");
         assert!(result.is_err());
         assert_eq!("`{{badges}}` was found in template but no badges were provided", result.unwrap_err());
     }
 
     #[test]
     fn template_with_license_tag_but_missing_license_should_fail() {
-        let result = super::process_template(TEMPLATE_WITH_LICENSE.to_owned(), String::new(), "", &[], None);
+        let result = super::process_template(TEMPLATE_WITH_LICENSE.to_owned(), String::new(), "", &[], None, "");
         assert!(result.is_err());
         assert_eq!("`{{license}}` was found in template but no license was provided", result.unwrap_err());
     }
 
     #[test]
     fn template_minimal() {
-        let result = super::process_template(TEMPLATE_MINIMAL.to_owned(), "readme".to_owned(), "", &[], None);
+        let result = super::process_template(TEMPLATE_MINIMAL.to_owned(), "readme".to_owned(), "", &[], None, "");
         assert!(result.is_ok());
         assert_eq!("readme", result.unwrap());
     }
 
     #[test]
     fn template_with_title() {
-        let result = super::process_template(TEMPLATE_WITH_TITLE.to_owned(), "readme".to_owned(), "title", &[], None);
+        let result = super::process_template(TEMPLATE_WITH_TITLE.to_owned(), "readme".to_owned(), "title", &[], None, "");
         assert!(result.is_ok());
         assert_eq!("# title\n\nreadme", result.unwrap());
     }
 
     #[test]
     fn template_with_badges() {
-        let result = super::process_template(TEMPLATE_WITH_BADGES.to_owned(), "readme".to_owned(), "", &["badge1", "badge2"], None);
+        let result = super::process_template(TEMPLATE_WITH_BADGES.to_owned(), "readme".to_owned(), "", &["badge1", "badge2"], None, "");
         assert!(result.is_ok());
         assert_eq!("badge1\nbadge2\n\nreadme", result.unwrap());
     }
 
     #[test]
     fn template_with_license() {
-        let result = super::process_template(TEMPLATE_WITH_LICENSE.to_owned(), "readme".to_owned(), "", &[], Some("license"));
+        let result = super::process_template(TEMPLATE_WITH_LICENSE.to_owned(), "readme".to_owned(), "", &[], Some("license"), "");
         assert!(result.is_ok());
         assert_eq!("readme\n\nlicense", result.unwrap());
     }
 
     #[test]
-    fn template_full() {
-        let result = super::process_template(TEMPLATE_FULL.to_owned(), "readme".to_owned(), "title", &["badge1", "badge2"], Some("license"));
+    fn template_with_version() {
+        let result = super::process_template(TEMPLATE_WITH_VERSION.to_owned(), "readme".to_owned(), "", &[], None, "3.0.1");
         assert!(result.is_ok());
-        assert_eq!("badge1\nbadge2\n\n# title\n\nreadme\n\nlicense", result.unwrap());
+        assert_eq!("readme\n\n3.0.1", result.unwrap());
+    }
+
+    #[test]
+    fn template_full() {
+        let result = super::process_template(TEMPLATE_FULL.to_owned(), "readme".to_owned(), "title", &["badge1", "badge2"], Some("license"), "3.0.2");
+        assert!(result.is_ok());
+        assert_eq!("badge1\nbadge2\n\n# title\n\nreadme\n\nlicense\n\n3.0.2", result.unwrap());
     }
 
     // process string

--- a/tests/project-with-version.rs
+++ b/tests/project-with-version.rs
@@ -1,0 +1,26 @@
+extern crate assert_cli;
+
+use assert_cli::Assert;
+
+const EXPECTED: &str = "# project-with-version
+
+Current version: 0.1.0
+
+A test project with a version provided.";
+
+#[test]
+fn template_with_version() {
+    let args = [
+        "readme",
+        "--project-root",
+        "tests/project-with-version",
+        "--template",
+        "README.tpl",
+    ];
+
+    Assert::main_binary()
+        .with_args(&args)
+        .succeeds()
+        .and().stdout().is(EXPECTED)
+        .unwrap();
+}

--- a/tests/project-with-version/.gitignore
+++ b/tests/project-with-version/.gitignore
@@ -1,0 +1,1 @@
+Cargo.lock

--- a/tests/project-with-version/Cargo.toml
+++ b/tests/project-with-version/Cargo.toml
@@ -1,0 +1,6 @@
+[package]
+name = "project-with-version"
+version = "0.1.0"
+authors = ["mexus <gilaldpellaeon@gmail.com>"]
+
+[dependencies]

--- a/tests/project-with-version/README.tpl
+++ b/tests/project-with-version/README.tpl
@@ -1,0 +1,5 @@
+# {{crate}}
+
+Current version: {{version}}
+
+{{readme}}

--- a/tests/project-with-version/src/lib.rs
+++ b/tests/project-with-version/src/lib.rs
@@ -1,0 +1,1 @@
+//! A test project with a version provided.


### PR DESCRIPTION
I really miss this functionality sometimes.. and so do some other people :)

While preparing the PR I've tried to follow the library's code style, but I definitely think it could use some `cargo fmt` ;)