### PR TITLE
change all HTTP url schemes to HTTPS

### DIFF
--- a/LICENSE-APACHE
+++ b/LICENSE-APACHE
@@ -1,6 +1,6 @@
                                  Apache License
                            Version 2.0, January 2004
-                        http://www.apache.org/licenses/
+                        https://www.apache.org/licenses/
 
    TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
 
@@ -192,11 +192,10 @@
    you may not use this file except in compliance with the License.
    You may obtain a copy of the License at
 
-       http://www.apache.org/licenses/LICENSE-2.0
+       https://www.apache.org/licenses/LICENSE-2.0
 
    Unless required by applicable law or agreed to in writing, software
    distributed under the License is distributed on an "AS IS" BASIS,
    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
    See the License for the specific language governing permissions and
    limitations under the License.
-

--- a/README.md
+++ b/README.md
@@ -140,8 +140,8 @@ By default, `README.tpl` will be used as the template, but you can override it u
 
 Licensed under either of
 
- * Apache License, Version 2.0, ([LICENSE-APACHE](LICENSE-APACHE) or http://www.apache.org/licenses/LICENSE-2.0)
- * MIT license ([LICENSE-MIT](LICENSE-MIT) or http://opensource.org/licenses/MIT)
+ * Apache License, Version 2.0, ([LICENSE-APACHE](LICENSE-APACHE) or https://www.apache.org/licenses/LICENSE-2.0)
+ * MIT license ([LICENSE-MIT](LICENSE-MIT) or https://opensource.org/licenses/MIT)
 
 at your option.
 

--- a/README.tpl
+++ b/README.tpl
@@ -8,8 +8,8 @@
 
 Licensed under either of
 
- * Apache License, Version 2.0, ([LICENSE-APACHE](LICENSE-APACHE) or http://www.apache.org/licenses/LICENSE-2.0)
- * MIT license ([LICENSE-MIT](LICENSE-MIT) or http://opensource.org/licenses/MIT)
+* Apache License, Version 2.0, ([LICENSE-APACHE](LICENSE-APACHE) or https://www.apache.org/licenses/LICENSE-2.0)
+* MIT license ([LICENSE-MIT](LICENSE-MIT) or https://opensource.org/licenses/MIT)
 
 at your option.
 

--- a/src/config/badges.rs
+++ b/src/config/badges.rs
@@ -84,8 +84,8 @@ pub fn coveralls(attrs: Attrs) -> String {
 pub fn is_it_maintained_issue_resolution(attrs: Attrs) -> String {
     let repo = &attrs["repository"];
     format!(
-        "[![Average time to resolve an issue](http://isitmaintained.com/badge/resolution/{repo}.svg)]\
-        (http://isitmaintained.com/project/{repo} \"Average time to resolve an issue\")",
+        "[![Average time to resolve an issue](https://isitmaintained.com/badge/resolution/{repo}.svg)]\
+        (https://isitmaintained.com/project/{repo} \"Average time to resolve an issue\")",
         repo=repo
     )
 }
@@ -93,8 +93,8 @@ pub fn is_it_maintained_issue_resolution(attrs: Attrs) -> String {
 pub fn is_it_maintained_open_issues(attrs: Attrs) -> String {
     let repo = &attrs["repository"];
     format!(
-        "[![Percentage of issues still open](http://isitmaintained.com/badge/open/{repo}.svg)]\
-        (http://isitmaintained.com/project/{repo} \"Percentage of issues still open\")",
+        "[![Percentage of issues still open](https://isitmaintained.com/badge/open/{repo}.svg)]\
+        (https://isitmaintained.com/project/{repo} \"Percentage of issues still open\")",
         repo=repo
     )
 }

--- a/tests/badges.rs
+++ b/tests/badges.rs
@@ -9,8 +9,8 @@ const EXPECTED: &str = r#"
 [![Build Status](https://travis-ci.org/cargo-readme/test.svg?branch=master)](https://travis-ci.org/cargo-readme/test)
 [![Coverage Status](https://codecov.io/gh/cargo-readme/test/branch/master/graph/badge.svg)](https://codecov.io/gh/cargo-readme/test)
 [![Coverage Status](https://coveralls.io/repos/github/cargo-readme/test/badge.svg?branch=branch)](https://coveralls.io/github/cargo-readme/test?branch=master)
-[![Average time to resolve an issue](http://isitmaintained.com/badge/resolution/cargo-readme/test.svg)](http://isitmaintained.com/project/cargo-readme/test "Average time to resolve an issue")
-[![Percentage of issues still open](http://isitmaintained.com/badge/open/cargo-readme/test.svg)](http://isitmaintained.com/project/cargo-readme/test "Percentage of issues still open")
+[![Average time to resolve an issue](https://isitmaintained.com/badge/resolution/cargo-readme/test.svg)](https://isitmaintained.com/project/cargo-readme/test "Average time to resolve an issue")
+[![Percentage of issues still open](https://isitmaintained.com/badge/open/cargo-readme/test.svg)](https://isitmaintained.com/project/cargo-readme/test "Percentage of issues still open")
 
 # readme-test
 


### PR DESCRIPTION
Minor change. I noticed the generated README shields for `isitmaintained.com` were using `http`, while the site also supports `https`. While at it, I also changed all license links to use https, and tested that they all work as expected.

There are some whitespace changes due to my editor configuration. I hope you don't mind. If you do, I will fix this in a follow-up commit.