### PR TITLE
swap CircleCI shield style to "shields.io"-style

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 [![Build Status](https://ci.appveyor.com/api/projects/status/github/livioribeiro/cargo-readme?branch=master&svg=true)](https://ci.appveyor.com/project/livioribeiro/cargo-readme/branch/master)
-[![Build Status](https://circleci.com/gh/livioribeiro/cargo-readme/tree/master.svg?style=svg)](https://circleci.com/gh/livioribeiro/cargo-readme/cargo-readme/tree/master)
+[![Build Status](https://circleci.com/gh/livioribeiro/cargo-readme/tree/master.svg?style=shield)](https://circleci.com/gh/livioribeiro/cargo-readme/cargo-readme/tree/master)
 [![Build Status](https://travis-ci.org/livioribeiro/cargo-readme.svg?branch=master)](https://travis-ci.org/livioribeiro/cargo-readme)
 
 # cargo-readme

--- a/src/config/badges.rs
+++ b/src/config/badges.rs
@@ -27,7 +27,7 @@ pub fn circle_ci(attrs: Attrs) -> String {
     );
 
     format!(
-        "[![Build Status](https://circleci.com/{service}/{repo}/tree/{branch}.svg?style=svg)]\
+        "[![Build Status](https://circleci.com/{service}/{repo}/tree/{branch}.svg?style=shield)]\
         (https://circleci.com/{service}/{repo}/cargo-readme/tree/{branch})",
         repo=repo, service=service, branch=percent_encode(branch)
     )

--- a/tests/badges.rs
+++ b/tests/badges.rs
@@ -4,7 +4,7 @@ use assert_cli::Assert;
 
 const EXPECTED: &str = r#"
 [![Build Status](https://ci.appveyor.com/api/projects/status/github/cargo-readme/test?branch=master&svg=true)](https://ci.appveyor.com/project/cargo-readme/test/branch/master)
-[![Build Status](https://circleci.com/gh/cargo-readme/test/tree/master.svg?style=svg)](https://circleci.com/gh/cargo-readme/test/cargo-readme/tree/master)
+[![Build Status](https://circleci.com/gh/cargo-readme/test/tree/master.svg?style=shield)](https://circleci.com/gh/cargo-readme/test/cargo-readme/tree/master)
 [![Build Status](https://gitlab.com/cargo-readme/test/badges/master/build.svg)](https://gitlab.com/cargo-readme/test/commits/master)
 [![Build Status](https://travis-ci.org/cargo-readme/test.svg?branch=master)](https://travis-ci.org/cargo-readme/test)
 [![Coverage Status](https://codecov.io/gh/cargo-readme/test/branch/master/graph/badge.svg)](https://codecov.io/gh/cargo-readme/test)


### PR DESCRIPTION
Minor change. I noticed the CircleCI badge style was out-of-place compared to the other styles (which all use shields.io styling). This fixes that.

See the relevant [CircleCI documentation](https://circleci.com/docs/2.0/status-badges/) for more details.