### PR TITLE
Fix processing of files starting with normal comments

### DIFF
--- a/src/readme/extract.rs
+++ b/src/readme/extract.rs
@@ -15,6 +15,8 @@ pub fn extract_docs<R: Read>(reader: R) -> io::Result<Vec<String>> {
         if line.starts_with("/*!") {
             return extract_docs_multiline_style(line, reader);
         }
+
+        line.clear();
     }
 
     Ok(Vec::new())

--- a/tests/test-project/src/lib.rs
+++ b/tests/test-project/src/lib.rs
@@ -1,3 +1,5 @@
+// Misleading first comment
+
 //! Test crate for cargo-readme
 //!
 //! # Level 1 heading should become level 2


### PR DESCRIPTION
During the refactoring in v3.0.0 release, the way the comments are
extracted was reworked, causing files with headers to not be properly
parsed.

This fixes the parsing, clearing lines under processing. Otherwise
every line was being concatenated inside of the buffer.

The test project has been adjusted so it exercises this use case as
well.

Signed-off-by: Otavio Salvador <otavio@ossystems.com.br>