### PR TITLE
Apply rustfmt to all code

### DIFF
--- a/src/config/badges.rs
+++ b/src/config/badges.rs
@@ -9,8 +9,14 @@ type Attrs = BTreeMap<String, String>;
 
 pub fn appveyor(attrs: Attrs) -> String {
     let repo = &attrs["repository"];
-    let branch = attrs.get("branch").map(|i| i.as_ref()).unwrap_or(BADGE_BRANCH_DEFAULT);
-    let service = attrs.get("service").map(|i| i.as_ref()).unwrap_or(BADGE_SERVICE_DEFAULT);
+    let branch = attrs
+        .get("branch")
+        .map(|i| i.as_ref())
+        .unwrap_or(BADGE_BRANCH_DEFAULT);
+    let service = attrs
+        .get("service")
+        .map(|i| i.as_ref())
+        .unwrap_or(BADGE_SERVICE_DEFAULT);
 
     format!(
         "[![Build Status](https://ci.appveyor.com/api/projects/status/{service}/{repo}?branch={branch}&svg=true)]\
@@ -21,63 +27,95 @@ pub fn appveyor(attrs: Attrs) -> String {
 
 pub fn circle_ci(attrs: Attrs) -> String {
     let repo = &attrs["repository"];
-    let branch = attrs.get("branch").map(|i| i.as_ref()).unwrap_or(BADGE_BRANCH_DEFAULT);
+    let branch = attrs
+        .get("branch")
+        .map(|i| i.as_ref())
+        .unwrap_or(BADGE_BRANCH_DEFAULT);
     let service = badge_service_short_name(
-        attrs.get("service").map(|i| i.as_ref()).unwrap_or(BADGE_SERVICE_DEFAULT)
+        attrs
+            .get("service")
+            .map(|i| i.as_ref())
+            .unwrap_or(BADGE_SERVICE_DEFAULT),
     );
 
     format!(
         "[![Build Status](https://circleci.com/{service}/{repo}/tree/{branch}.svg?style=shield)]\
-        (https://circleci.com/{service}/{repo}/cargo-readme/tree/{branch})",
-        repo=repo, service=service, branch=percent_encode(branch)
+         (https://circleci.com/{service}/{repo}/cargo-readme/tree/{branch})",
+        repo = repo,
+        service = service,
+        branch = percent_encode(branch)
     )
 }
 
 pub fn gitlab(attrs: Attrs) -> String {
     let repo = &attrs["repository"];
-    let branch = attrs.get("branch").map(|i| i.as_ref()).unwrap_or(BADGE_BRANCH_DEFAULT);
+    let branch = attrs
+        .get("branch")
+        .map(|i| i.as_ref())
+        .unwrap_or(BADGE_BRANCH_DEFAULT);
 
     format!(
         "[![Build Status](https://gitlab.com/{repo}/badges/{branch}/build.svg)]\
-        (https://gitlab.com/{repo}/commits/master)",
-        repo=repo, branch=percent_encode(branch)
+         (https://gitlab.com/{repo}/commits/master)",
+        repo = repo,
+        branch = percent_encode(branch)
     )
 }
 
 pub fn travis_ci(attrs: Attrs) -> String {
     let repo = &attrs["repository"];
-    let branch = attrs.get("branch").map(|i| i.as_ref()).unwrap_or(BADGE_BRANCH_DEFAULT);
+    let branch = attrs
+        .get("branch")
+        .map(|i| i.as_ref())
+        .unwrap_or(BADGE_BRANCH_DEFAULT);
 
     format!(
         "[![Build Status](https://travis-ci.org/{repo}.svg?branch={branch})]\
-        (https://travis-ci.org/{repo})",
-        repo=repo, branch=percent_encode(branch)
+         (https://travis-ci.org/{repo})",
+        repo = repo,
+        branch = percent_encode(branch)
     )
 }
 
 pub fn codecov(attrs: Attrs) -> String {
     let repo = &attrs["repository"];
-    let branch = attrs.get("branch").map(|i| i.as_ref()).unwrap_or(BADGE_BRANCH_DEFAULT);
+    let branch = attrs
+        .get("branch")
+        .map(|i| i.as_ref())
+        .unwrap_or(BADGE_BRANCH_DEFAULT);
     let service = badge_service_short_name(
-        attrs.get("service").map(|i| i.as_ref()).unwrap_or(BADGE_SERVICE_DEFAULT)
+        attrs
+            .get("service")
+            .map(|i| i.as_ref())
+            .unwrap_or(BADGE_SERVICE_DEFAULT),
     );
 
     format!(
         "[![Coverage Status](https://codecov.io/{service}/{repo}/branch/{branch}/graph/badge.svg)]\
-        (https://codecov.io/{service}/{repo})",
-        repo=repo, branch=percent_encode(branch), service=service
+         (https://codecov.io/{service}/{repo})",
+        repo = repo,
+        branch = percent_encode(branch),
+        service = service
     )
 }
 
 pub fn coveralls(attrs: Attrs) -> String {
     let repo = &attrs["repository"];
-    let branch = attrs.get("branch").map(|i| i.as_ref()).unwrap_or(BADGE_BRANCH_DEFAULT);
-    let service = attrs.get("service").map(|i| i.as_ref()).unwrap_or(BADGE_SERVICE_DEFAULT);
+    let branch = attrs
+        .get("branch")
+        .map(|i| i.as_ref())
+        .unwrap_or(BADGE_BRANCH_DEFAULT);
+    let service = attrs
+        .get("service")
+        .map(|i| i.as_ref())
+        .unwrap_or(BADGE_SERVICE_DEFAULT);
 
     format!(
         "[![Coverage Status](https://coveralls.io/repos/{service}/{repo}/badge.svg?branch=branch)]\
-        (https://coveralls.io/{service}/{repo}?branch={branch})",
-        repo=repo, branch=percent_encode(branch), service=service
+         (https://coveralls.io/{service}/{repo}?branch={branch})",
+        repo = repo,
+        branch = percent_encode(branch),
+        service = service
     )
 }
 
@@ -94,8 +132,8 @@ pub fn is_it_maintained_open_issues(attrs: Attrs) -> String {
     let repo = &attrs["repository"];
     format!(
         "[![Percentage of issues still open](https://isitmaintained.com/badge/open/{repo}.svg)]\
-        (https://isitmaintained.com/project/{repo} \"Percentage of issues still open\")",
-        repo=repo
+         (https://isitmaintained.com/project/{repo} \"Percentage of issues still open\")",
+        repo = repo
     )
 }
 

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -2,5 +2,5 @@ mod badges;
 mod manifest;
 pub mod project;
 
-pub use self::manifest::Manifest;
 pub use self::manifest::get_manifest;
+pub use self::manifest::Manifest;

--- a/src/config/project.rs
+++ b/src/config/project.rs
@@ -1,7 +1,7 @@
 use std::env;
 use std::path::{Path, PathBuf};
 
-use ::config::manifest::{Manifest, ManifestLib};
+use config::manifest::{Manifest, ManifestLib};
 
 /// Get the project root from given path or defaults to current directory
 ///
@@ -54,19 +54,29 @@ pub fn find_entrypoint(current_dir: &Path, manifest: &Manifest) -> Result<PathBu
     }
 
     // try lib defined in `Cargo.toml`
-    if let Some(ManifestLib { path: ref lib, doc: true }) = manifest.lib {
-        return Ok(lib.to_path_buf())
+    if let Some(ManifestLib {
+        path: ref lib,
+        doc: true,
+    }) = manifest.lib
+    {
+        return Ok(lib.to_path_buf());
     }
 
     // try bin defined in `Cargo.toml`
     if manifest.bin.len() > 0 {
-        let mut bin_list: Vec<_> = manifest.bin.iter()
+        let mut bin_list: Vec<_> = manifest
+            .bin
+            .iter()
             .filter(|b| b.doc == true)
             .map(|b| b.path.clone())
             .collect();
 
         if bin_list.len() > 1 {
-            let paths = bin_list.iter().map(|p| p.to_string_lossy()).collect::<Vec<_>>().join(", ");
+            let paths = bin_list
+                .iter()
+                .map(|p| p.to_string_lossy())
+                .collect::<Vec<_>>()
+                .join(", ");
             return Err(format!("Multiple binaries found, choose one: [{}]", paths));
         }
 

--- a/src/helper.rs
+++ b/src/helper.rs
@@ -1,5 +1,5 @@
-use std::io::{Write, ErrorKind};
 use std::fs::File;
+use std::io::{ErrorKind, Write};
 use std::path::{Path, PathBuf};
 
 use cargo_readme::get_manifest;
@@ -13,7 +13,7 @@ const DEFAULT_TEMPLATE: &'static str = "README.tpl";
 /// as is. If no path is given, the current directory is used.
 /// A `Cargo.toml` file must be present is the root directory.
 pub fn get_project_root(given_root: Option<&str>) -> Result<PathBuf, String> {
-   project::get_root(given_root)
+    project::get_root(given_root)
 }
 
 /// Get the source file from which the doc comments will be extracted
@@ -21,9 +21,8 @@ pub fn get_source(project_root: &Path, input: Option<&str>) -> Result<File, Stri
     match input {
         Some(input) => {
             let input = project_root.join(input);
-            File::open(&input).map_err(|e| {
-                format!("Could not open file '{}': {}", input.to_string_lossy(), e)
-            })
+            File::open(&input)
+                .map_err(|e| format!("Could not open file '{}': {}", input.to_string_lossy(), e))
         }
         None => find_entrypoint(&project_root),
     }
@@ -47,7 +46,10 @@ pub fn get_dest(project_root: &Path, output: Option<&str>) -> Result<Option<File
 }
 
 /// Get the template file that will be used to render the output
-pub fn get_template_file(project_root: &Path, template: Option<&str>) -> Result<Option<File>, String> {
+pub fn get_template_file(
+    project_root: &Path,
+    template: Option<&str>,
+) -> Result<Option<File>, String> {
     match template {
         // template path was given, try to read it
         Some(template) => {
@@ -69,8 +71,7 @@ pub fn get_template_file(project_root: &Path, template: Option<&str>) -> Result<
                 Err(ref e) if e.kind() != ErrorKind::NotFound => {
                     return Err(format!(
                         "Could not open template file '{}': {}",
-                        DEFAULT_TEMPLATE,
-                        e
+                        DEFAULT_TEMPLATE, e
                     ))
                 }
                 // default template not found, return `None`
@@ -88,9 +89,9 @@ pub fn write_output(dest: &mut Option<File>, readme: String) -> Result<(), Strin
             // Append new line at end of file to match behavior of `cargo readme > README.md`
             bytes.push(b'\n');
 
-            dest.write_all(&mut bytes).map(|_| ()).map_err(|e| {
-                format!("Could not write to output file: {}", e)
-            })?;
+            dest.write_all(&mut bytes)
+                .map(|_| ())
+                .map_err(|e| format!("Could not write to output file: {}", e))?;
         }
         None => println!("{}", readme),
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -65,7 +65,7 @@
 //! ~~~
 //!
 //! Let's see what's happened:
-//! 
+//!
 //! - a badge was created from the one defined in the `[badges]` section of `Cargo.toml`
 //! - the crate name ("my-crate") was added
 //! - "# Examples" heading became "## Examples"
@@ -136,16 +136,18 @@
 //! By default, `README.tpl` will be used as the template, but you can override it using the
 //! `--template` to choose a different template or `--no-template` to disable it.
 
-#[macro_use] extern crate serde_derive;
-#[macro_use] extern crate lazy_static;
+#[macro_use]
+extern crate serde_derive;
+#[macro_use]
+extern crate lazy_static;
 
+extern crate percent_encoding;
 extern crate regex;
 extern crate toml;
-extern crate percent_encoding;
 
-mod readme;
 mod config;
+mod readme;
 
-pub use readme::generate_readme;
 pub use config::get_manifest;
 pub use config::project;
+pub use readme::generate_readme;

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,12 +1,13 @@
 //! Generate README.md from doc comments.
 
-#[macro_use] extern crate clap;
+#[macro_use]
+extern crate clap;
 
 extern crate cargo_readme;
 
 use std::io::{self, Write};
 
-use clap::{Arg, ArgMatches, App, AppSettings, SubCommand};
+use clap::{App, AppSettings, Arg, ArgMatches, SubCommand};
 
 mod helper;
 

--- a/src/readme/extract.rs
+++ b/src/readme/extract.rs
@@ -1,6 +1,6 @@
 //! Extract raw doc comments from rust source code
 
-use std::io::{self, Read, BufRead, BufReader};
+use std::io::{self, BufRead, BufReader, Read};
 
 /// Read the given `Read`er and return a `Vec` of the rustdoc lines found
 pub fn extract_docs<R: Read>(reader: R) -> io::Result<Vec<String>> {
@@ -20,7 +20,10 @@ pub fn extract_docs<R: Read>(reader: R) -> io::Result<Vec<String>> {
     Ok(Vec::new())
 }
 
-fn extract_docs_singleline_style<R: Read>(first_line: String, reader: BufReader<R>) -> io::Result<Vec<String>> {
+fn extract_docs_singleline_style<R: Read>(
+    first_line: String,
+    reader: BufReader<R>,
+) -> io::Result<Vec<String>> {
     let mut result = vec![normalize_line(first_line)];
 
     for line in reader.lines() {
@@ -37,7 +40,10 @@ fn extract_docs_singleline_style<R: Read>(first_line: String, reader: BufReader<
     Ok(result)
 }
 
-fn extract_docs_multiline_style<R: Read>(first_line: String, reader: BufReader<R>) -> io::Result<Vec<String>> {
+fn extract_docs_multiline_style<R: Read>(
+    first_line: String,
+    reader: BufReader<R>,
+) -> io::Result<Vec<String>> {
     let mut result = Vec::new();
     if first_line.starts_with("/*!") && first_line.trim().len() > "/*!".len() {
         result.push(normalize_line(first_line));
@@ -57,7 +63,7 @@ fn extract_docs_multiline_style<R: Read>(first_line: String, reader: BufReader<R
                 if !line.trim().is_empty() {
                     result.push(line);
                 }
-                break
+                break;
             }
         }
 
@@ -81,8 +87,8 @@ fn normalize_line(mut line: String) -> String {
 
 #[cfg(test)]
 mod tests {
-    use std::io::Cursor;
     use super::*;
+    use std::io::Cursor;
 
     const EXPECTED: &[&str] = &[
         "first line",
@@ -97,17 +103,17 @@ mod tests {
     ];
 
     const INPUT_SINGLELINE: &str = "\
-        //! first line \n\
-        //! \n\
-        //! ``` \n\
-        //! let rust_code = \"safe\"; \n\
-        //! ``` \n\
-        //! \n\
-        //! ```C \n\
-        //! int i = 0; // no rust code \n\
-        //! ``` \n\
-        use std::any::Any; \n\
-        fn main() {}";
+                                    //! first line \n\
+                                    //! \n\
+                                    //! ``` \n\
+                                    //! let rust_code = \"safe\"; \n\
+                                    //! ``` \n\
+                                    //! \n\
+                                    //! ```C \n\
+                                    //! int i = 0; // no rust code \n\
+                                    //! ``` \n\
+                                    use std::any::Any; \n\
+                                    fn main() {}";
 
     #[test]
     fn extract_docs_singleline_style() {
@@ -117,19 +123,19 @@ mod tests {
     }
 
     const INPUT_MULTILINE: &str = "\
-        /*! \n\
-        first line \n\
-         \n\
-        ``` \n\
-        let rust_code = \"safe\"; \n\
-        ``` \n\
-         \n\
-        ```C \n\
-        int i = 0; // no rust code \n\
-        ``` \n\
-        */ \n\
-        use std::any::Any; \n\
-        fn main() {}";
+                                   /*! \n\
+                                   first line \n\
+                                   \n\
+                                   ``` \n\
+                                   let rust_code = \"safe\"; \n\
+                                   ``` \n\
+                                   \n\
+                                   ```C \n\
+                                   int i = 0; // no rust code \n\
+                                   ``` \n\
+                                   */ \n\
+                                   use std::any::Any; \n\
+                                   fn main() {}";
 
     #[test]
     fn extract_docs_multiline_style() {
@@ -139,10 +145,10 @@ mod tests {
     }
 
     const INPUT_MIXED_SINGLELINE: &str = "\
-        //! singleline \n\
-        /*! \n\
-        multiline \n\
-        */";
+                                          //! singleline \n\
+                                          /*! \n\
+                                          multiline \n\
+                                          */";
 
     #[test]
     fn extract_docs_mix_styles_singleline() {
@@ -153,10 +159,10 @@ mod tests {
     }
 
     const INPUT_MIXED_MULTILINE: &str = "\
-        /*! \n\
-        multiline \n\
-        */ \n\
-        //! singleline";
+                                         /*! \n\
+                                         multiline \n\
+                                         */ \n\
+                                         //! singleline";
 
     #[test]
     fn extract_docs_mix_styles_multiline() {
@@ -167,22 +173,16 @@ mod tests {
     }
 
     const INPUT_MULTILINE_NESTED_1: &str = "\
-        /*! \n\
-        level 0 \n\
-        /* \n\
-        level 1 \n\
-        */ \n\
-        level 0 \n\
-        */ \n\
-        fn main() {}";
+                                            /*! \n\
+                                            level 0 \n\
+                                            /* \n\
+                                            level 1 \n\
+                                            */ \n\
+                                            level 0 \n\
+                                            */ \n\
+                                            fn main() {}";
 
-    const EXPECTED_MULTILINE_NESTED_1: &[&str] = &[
-        "level 0",
-        "/*",
-        "level 1",
-        "*/",
-        "level 0",
-    ];
+    const EXPECTED_MULTILINE_NESTED_1: &[&str] = &["level 0", "/*", "level 1", "*/", "level 0"];
 
     #[test]
     fn extract_docs_nested_level_1() {
@@ -192,29 +192,21 @@ mod tests {
     }
 
     const INPUT_MULTILINE_NESTED_2: &str = "\
-        /*! \n\
-        level 0 \n\
-        /* \n\
-        level 1 \n\
-        /* \n\
-        level 2 \n\
-        */ \n\
-        level 1 \n\
-        */ \n\
-        level 0 \n\
-        */ \n\
-        fn main() {}";
+                                            /*! \n\
+                                            level 0 \n\
+                                            /* \n\
+                                            level 1 \n\
+                                            /* \n\
+                                            level 2 \n\
+                                            */ \n\
+                                            level 1 \n\
+                                            */ \n\
+                                            level 0 \n\
+                                            */ \n\
+                                            fn main() {}";
 
     const EXPECTED_MULTILINE_NESTED_2: &[&str] = &[
-        "level 0",
-        "/*",
-        "level 1",
-        "/*",
-        "level 2",
-        "*/",
-        "level 1",
-        "*/",
-        "level 0",
+        "level 0", "/*", "level 1", "/*", "level 2", "*/", "level 1", "*/", "level 0",
     ];
 
     #[test]

--- a/src/readme/mod.rs
+++ b/src/readme/mod.rs
@@ -5,7 +5,7 @@ mod extract;
 mod process;
 mod template;
 
-use ::config;
+use config;
 
 /// Generates readme data from `source` file
 ///
@@ -19,9 +19,7 @@ pub fn generate_readme<T: Read>(
     add_license: bool,
     indent_headings: bool,
 ) -> Result<String, String> {
-
-    let lines = extract::extract_docs(source)
-        .map_err(|e| format!("{}", e))?;
+    let lines = extract::extract_docs(source).map_err(|e| format!("{}", e))?;
 
     let readme = process::process_docs(lines, indent_headings).join("\n");
 

--- a/src/readme/process.rs
+++ b/src/readme/process.rs
@@ -4,7 +4,7 @@
 //! - "```", "```no_run", "```ignore" and "```should_panic" are converted to "```rust"
 //! - markdown heading are indentend to be one level lower, so the crate name is at the top level
 
-use std::iter::{Iterator, IntoIterator};
+use std::iter::{IntoIterator, Iterator};
 
 use regex::Regex;
 
@@ -21,9 +21,11 @@ lazy_static!{
 ///
 /// The processing transforms doc tests into regular rust code blocks and optionally indent the
 /// markdown headings in order to leave the top heading to the crate name
-pub fn process_docs<S: Into<String>, L: Into<Vec<S>>>(lines: L, indent_headings: bool) -> Vec<String> {
-    lines.into().into_iter()
-        .process_docs(indent_headings)
+pub fn process_docs<S: Into<String>, L: Into<Vec<S>>>(
+    lines: L,
+    indent_headings: bool,
+) -> Vec<String> {
+    lines.into().into_iter().process_docs(indent_headings)
 }
 
 pub struct Processor {
@@ -94,7 +96,6 @@ pub trait DocProcess<S: Into<String>> {
 
 impl<S: Into<String>, I: Iterator<Item = S>> DocProcess<S> for I {}
 
-
 #[cfg(test)]
 mod tests {
     use super::process_docs;
@@ -107,12 +108,8 @@ mod tests {
         "```",
     ];
 
-    const EXPECTED_HIDDEN_LINE: &[&str] = &[
-        "```rust",
-        "#[visible]",
-        "let visible = \"visible\";",
-        "```",
-    ];
+    const EXPECTED_HIDDEN_LINE: &[&str] =
+        &["```rust", "#[visible]", "let visible = \"visible\";", "```"];
 
     #[test]
     fn hide_line_in_rust_code_block() {
@@ -227,17 +224,9 @@ mod tests {
         assert_eq!(result, EXPECTED_RUST_CODE_BLOCK);
     }
 
-    const INPUT_TEXT_BLOCK: &[&str] = &[
-        "```text",
-        "this is text",
-        "```",
-    ];
+    const INPUT_TEXT_BLOCK: &[&str] = &["```text", "this is text", "```"];
 
-    const EXPECTED_TEXT_BLOCK: &[&str] = &[
-        "```",
-        "this is text",
-        "```",
-    ];
+    const EXPECTED_TEXT_BLOCK: &[&str] = &["```", "this is text", "```"];
 
     #[test]
     fn transform_text_block() {
@@ -287,17 +276,9 @@ mod tests {
         assert_eq!(result, INPUT_INDENT_HEADINGS);
     }
 
-    const INPUT_ALTERNATE_DELIMITER_4_BACKTICKS: &[&str] = &[
-        "````",
-        "let i = 1;",
-        "````",
-    ];
+    const INPUT_ALTERNATE_DELIMITER_4_BACKTICKS: &[&str] = &["````", "let i = 1;", "````"];
 
-    const EXPECTED_ALTERNATE_DELIMITER_4_BACKTICKS: &[&str] = &[
-        "````rust",
-        "let i = 1;",
-        "````",
-    ];
+    const EXPECTED_ALTERNATE_DELIMITER_4_BACKTICKS: &[&str] = &["````rust", "let i = 1;", "````"];
 
     #[test]
     fn alternate_delimiter_4_backticks() {
@@ -333,17 +314,9 @@ mod tests {
         assert_eq!(result, EXPECTED_ALTERNATE_DELIMITER_4_BACKTICKS_NESTED);
     }
 
-    const INPUT_ALTERNATE_DELIMITER_3_TILDES: &[&str] = &[
-        "~~~",
-        "let i = 1;",
-        "~~~",
-    ];
+    const INPUT_ALTERNATE_DELIMITER_3_TILDES: &[&str] = &["~~~", "let i = 1;", "~~~"];
 
-    const EXPECTED_ALTERNATE_DELIMITER_3_TILDES: &[&str] = &[
-        "~~~rust",
-        "let i = 1;",
-        "~~~",
-    ];
+    const EXPECTED_ALTERNATE_DELIMITER_3_TILDES: &[&str] = &["~~~rust", "let i = 1;", "~~~"];
 
     #[test]
     fn alternate_delimiter_3_tildes() {
@@ -351,17 +324,9 @@ mod tests {
         assert_eq!(result, EXPECTED_ALTERNATE_DELIMITER_3_TILDES);
     }
 
-    const INPUT_ALTERNATE_DELIMITER_4_TILDES: &[&str] = &[
-        "~~~~",
-        "let i = 1;",
-        "~~~~",
-    ];
+    const INPUT_ALTERNATE_DELIMITER_4_TILDES: &[&str] = &["~~~~", "let i = 1;", "~~~~"];
 
-    const EXPECTED_ALTERNATE_DELIMITER_4_TILDES: &[&str] = &[
-        "~~~~rust",
-        "let i = 1;",
-        "~~~~",
-    ];
+    const EXPECTED_ALTERNATE_DELIMITER_4_TILDES: &[&str] = &["~~~~rust", "let i = 1;", "~~~~"];
 
     #[test]
     fn alternate_delimiter_4_tildes() {

--- a/src/readme/template.rs
+++ b/src/readme/template.rs
@@ -1,4 +1,4 @@
-use ::config::Manifest;
+use config::Manifest;
 
 /// Renders the template
 ///
@@ -23,7 +23,15 @@ pub fn render(
     if let Some(template) = template {
         process_template(template, readme, title, badges, license, version)
     } else {
-        process_string(readme, title, badges, license, add_title, add_badges, add_license)
+        process_string(
+            readme,
+            title,
+            badges,
+            license,
+            add_title,
+            add_badges,
+            add_license,
+        )
     }
 }
 
@@ -43,7 +51,6 @@ fn process_template(
     license: Option<&str>,
     version: &str,
 ) -> Result<String, String> {
-
     template = template.trim_right_matches("\n").to_owned();
 
     if !template.contains("{{readme}}") {
@@ -56,9 +63,7 @@ fn process_template(
 
     if template.contains("{{badges}}") {
         if badges.is_empty() {
-            return Err(
-                "`{{badges}}` was found in template but no badges were provided".to_owned(),
-            );
+            return Err("`{{badges}}` was found in template but no badges were provided".to_owned());
         }
         let badges = badges.join("\n");
         template = template.replace("{{badges}}", &badges);
@@ -69,7 +74,7 @@ fn process_template(
             template = template.replace("{{license}}", &license);
         } else {
             return Err(
-                "`{{license}}` was found in template but no license was provided".to_owned()
+                "`{{license}}` was found in template but no license was provided".to_owned(),
             );
         }
     }
@@ -81,7 +86,15 @@ fn process_template(
 }
 
 /// Process output without template
-fn process_string(mut readme: String, title: &str, badges: &[&str], license: Option<&str>, add_title: bool, add_badges: bool, add_license: bool) -> Result<String, String> {
+fn process_string(
+    mut readme: String,
+    title: &str,
+    badges: &[&str],
+    license: Option<&str>,
+    add_title: bool,
+    add_badges: bool,
+    add_license: bool,
+) -> Result<String, String> {
     if add_title {
         readme = prepend_title(readme, title);
     }
@@ -140,7 +153,8 @@ mod tests {
     const TEMPLATE_WITH_BADGES: &str = "{{badges}}\n\n{{readme}}";
     const TEMPLATE_WITH_LICENSE: &str = "{{readme}}\n\n{{license}}";
     const TEMPLATE_WITH_VERSION: &str = "{{readme}}\n\n{{version}}";
-    const TEMPLATE_FULL: &str = "{{badges}}\n\n# {{crate}}\n\n{{readme}}\n\n{{license}}\n\n{{version}}";
+    const TEMPLATE_FULL: &str =
+        "{{badges}}\n\n# {{crate}}\n\n{{readme}}\n\n{{license}}\n\n{{version}}";
 
     // process template
     #[test]
@@ -152,58 +166,123 @@ mod tests {
 
     #[test]
     fn template_with_badge_tag_but_missing_badges_should_fail() {
-        let result = super::process_template(TEMPLATE_WITH_BADGES.to_owned(), String::new(), "", &[], None, "");
+        let result = super::process_template(
+            TEMPLATE_WITH_BADGES.to_owned(),
+            String::new(),
+            "",
+            &[],
+            None,
+            "",
+        );
         assert!(result.is_err());
-        assert_eq!("`{{badges}}` was found in template but no badges were provided", result.unwrap_err());
+        assert_eq!(
+            "`{{badges}}` was found in template but no badges were provided",
+            result.unwrap_err()
+        );
     }
 
     #[test]
     fn template_with_license_tag_but_missing_license_should_fail() {
-        let result = super::process_template(TEMPLATE_WITH_LICENSE.to_owned(), String::new(), "", &[], None, "");
+        let result = super::process_template(
+            TEMPLATE_WITH_LICENSE.to_owned(),
+            String::new(),
+            "",
+            &[],
+            None,
+            "",
+        );
         assert!(result.is_err());
-        assert_eq!("`{{license}}` was found in template but no license was provided", result.unwrap_err());
+        assert_eq!(
+            "`{{license}}` was found in template but no license was provided",
+            result.unwrap_err()
+        );
     }
 
     #[test]
     fn template_minimal() {
-        let result = super::process_template(TEMPLATE_MINIMAL.to_owned(), "readme".to_owned(), "", &[], None, "");
+        let result = super::process_template(
+            TEMPLATE_MINIMAL.to_owned(),
+            "readme".to_owned(),
+            "",
+            &[],
+            None,
+            "",
+        );
         assert!(result.is_ok());
         assert_eq!("readme", result.unwrap());
     }
 
     #[test]
     fn template_with_title() {
-        let result = super::process_template(TEMPLATE_WITH_TITLE.to_owned(), "readme".to_owned(), "title", &[], None, "");
+        let result = super::process_template(
+            TEMPLATE_WITH_TITLE.to_owned(),
+            "readme".to_owned(),
+            "title",
+            &[],
+            None,
+            "",
+        );
         assert!(result.is_ok());
         assert_eq!("# title\n\nreadme", result.unwrap());
     }
 
     #[test]
     fn template_with_badges() {
-        let result = super::process_template(TEMPLATE_WITH_BADGES.to_owned(), "readme".to_owned(), "", &["badge1", "badge2"], None, "");
+        let result = super::process_template(
+            TEMPLATE_WITH_BADGES.to_owned(),
+            "readme".to_owned(),
+            "",
+            &["badge1", "badge2"],
+            None,
+            "",
+        );
         assert!(result.is_ok());
         assert_eq!("badge1\nbadge2\n\nreadme", result.unwrap());
     }
 
     #[test]
     fn template_with_license() {
-        let result = super::process_template(TEMPLATE_WITH_LICENSE.to_owned(), "readme".to_owned(), "", &[], Some("license"), "");
+        let result = super::process_template(
+            TEMPLATE_WITH_LICENSE.to_owned(),
+            "readme".to_owned(),
+            "",
+            &[],
+            Some("license"),
+            "",
+        );
         assert!(result.is_ok());
         assert_eq!("readme\n\nlicense", result.unwrap());
     }
 
     #[test]
     fn template_with_version() {
-        let result = super::process_template(TEMPLATE_WITH_VERSION.to_owned(), "readme".to_owned(), "", &[], None, "3.0.1");
+        let result = super::process_template(
+            TEMPLATE_WITH_VERSION.to_owned(),
+            "readme".to_owned(),
+            "",
+            &[],
+            None,
+            "3.0.1",
+        );
         assert!(result.is_ok());
         assert_eq!("readme\n\n3.0.1", result.unwrap());
     }
 
     #[test]
     fn template_full() {
-        let result = super::process_template(TEMPLATE_FULL.to_owned(), "readme".to_owned(), "title", &["badge1", "badge2"], Some("license"), "3.0.2");
+        let result = super::process_template(
+            TEMPLATE_FULL.to_owned(),
+            "readme".to_owned(),
+            "title",
+            &["badge1", "badge2"],
+            Some("license"),
+            "3.0.2",
+        );
         assert!(result.is_ok());
-        assert_eq!("badge1\nbadge2\n\n# title\n\nreadme\n\nlicense\n\n3.0.2", result.unwrap());
+        assert_eq!(
+            "badge1\nbadge2\n\n# title\n\nreadme\n\nlicense\n\n3.0.2",
+            result.unwrap()
+        );
     }
 
     // process string
@@ -216,35 +295,71 @@ mod tests {
 
     #[test]
     fn render_title() {
-        let result = super::process_string("readme".to_owned(), "title", &[], None, true, false, false);
+        let result =
+            super::process_string("readme".to_owned(), "title", &[], None, true, false, false);
         assert!(result.is_ok());
         assert_eq!("# title\n\nreadme", result.unwrap());
     }
 
     #[test]
     fn render_badges() {
-        let result = super::process_string("readme".to_owned(), "", &["badge1", "badge2"], None, false, true, false);
+        let result = super::process_string(
+            "readme".to_owned(),
+            "",
+            &["badge1", "badge2"],
+            None,
+            false,
+            true,
+            false,
+        );
         assert!(result.is_ok());
         assert_eq!("badge1\nbadge2\n\nreadme", result.unwrap());
     }
 
     #[test]
     fn render_license() {
-        let result = super::process_string("readme".to_owned(), "", &[], Some("license"), false, false, true);
+        let result = super::process_string(
+            "readme".to_owned(),
+            "",
+            &[],
+            Some("license"),
+            false,
+            false,
+            true,
+        );
         assert!(result.is_ok());
         assert_eq!("readme\n\nLicense: license", result.unwrap());
     }
 
     #[test]
     fn render_full() {
-        let result = super::process_string("readme".to_owned(), "title", &["badge1", "badge2"], Some("license"), true, true, true);
+        let result = super::process_string(
+            "readme".to_owned(),
+            "title",
+            &["badge1", "badge2"],
+            Some("license"),
+            true,
+            true,
+            true,
+        );
         assert!(result.is_ok());
-        assert_eq!("badge1\nbadge2\n\n# title\n\nreadme\n\nLicense: license", result.unwrap());
+        assert_eq!(
+            "badge1\nbadge2\n\n# title\n\nreadme\n\nLicense: license",
+            result.unwrap()
+        );
     }
 
     #[test]
     fn render_nothing() {
-        let result = super::process_string("readme".to_owned(), "title", &["badge1", "badge2"], Some("license"), false, false, false);
+        let result = super::process_string(
+            "readme".to_owned(),
+            "title",
+            &["badge1", "badge2"],
+            Some("license"),
+            false,
+            false,
+            false,
+        );
         assert!(result.is_ok());
         assert_eq!("readme", result.unwrap());
     }

--- a/tests/alternate-input.rs
+++ b/tests/alternate-input.rs
@@ -17,7 +17,9 @@ fn alternate_input_empty_docs() {
     Assert::main_binary()
         .with_args(&args)
         .succeeds()
-        .and().stdout().is("# readme-test\n\nLicense: MIT")
+        .and()
+        .stdout()
+        .is("# readme-test\n\nLicense: MIT")
         .unwrap();
 }
 
@@ -44,7 +46,9 @@ License: MIT
     Assert::main_binary()
         .with_args(&args)
         .succeeds()
-        .and().stdout().is(expected)
+        .and()
+        .stdout()
+        .is(expected)
         .unwrap();
 }
 
@@ -73,6 +77,8 @@ License: MIT
     Assert::main_binary()
         .with_args(&args)
         .succeeds()
-        .and().stdout().is(expected)
+        .and()
+        .stdout()
+        .is(expected)
         .unwrap();
 }

--- a/tests/alternate-template.rs
+++ b/tests/alternate-template.rs
@@ -59,6 +59,8 @@ fn alternate_template() {
     Assert::main_binary()
         .with_args(&args)
         .succeeds()
-        .and().stdout().is(EXPECTED)
+        .and()
+        .stdout()
+        .is(EXPECTED)
         .unwrap();
 }

--- a/tests/append-license.rs
+++ b/tests/append-license.rs
@@ -51,7 +51,7 @@ fn append_license() {
         "--project-root",
         "tests/test-project",
         "--no-template",
-        "--no-badges"
+        "--no-badges",
     ];
 
     let expected = format!("{}\n\n{}", EXPECTED.trim(), "License: MIT");
@@ -59,7 +59,9 @@ fn append_license() {
     Assert::main_binary()
         .with_args(&args)
         .succeeds()
-        .and().stdout().is(&*expected)
+        .and()
+        .stdout()
+        .is(&*expected)
         .unwrap();
 }
 
@@ -77,6 +79,8 @@ fn no_append_license() {
     Assert::main_binary()
         .with_args(&args)
         .succeeds()
-        .and().stdout().is(EXPECTED)
+        .and()
+        .stdout()
+        .is(EXPECTED)
         .unwrap();
 }

--- a/tests/badges.rs
+++ b/tests/badges.rs
@@ -21,15 +21,13 @@ License: MIT
 
 #[test]
 fn badges() {
-    let args = [
-        "readme",
-        "--project-root",
-        "tests/badges",
-    ];
+    let args = ["readme", "--project-root", "tests/badges"];
 
     Assert::main_binary()
         .with_args(&args)
         .succeeds()
-        .and().stdout().is(EXPECTED)
+        .and()
+        .stdout()
+        .is(EXPECTED)
         .unwrap();
 }

--- a/tests/default-behavior.rs
+++ b/tests/default-behavior.rs
@@ -55,6 +55,8 @@ fn default_behavior() {
     Assert::main_binary()
         .with_args(&args)
         .succeeds()
-        .and().stdout().is(EXPECTED)
+        .and()
+        .stdout()
+        .is(EXPECTED)
         .unwrap();
 }

--- a/tests/entrypoint-resolution.rs
+++ b/tests/entrypoint-resolution.rs
@@ -9,13 +9,15 @@ fn entrypoint_resolution_main() {
         "--project-root",
         "tests/entrypoint-resolution/main",
         "--no-title",
-        "--no-license"
+        "--no-license",
     ];
 
     Assert::main_binary()
         .with_args(&args)
         .succeeds()
-        .and().stdout().is("main")
+        .and()
+        .stdout()
+        .is("main")
         .unwrap();
 }
 
@@ -26,13 +28,15 @@ fn entrypoint_resolution_lib() {
         "--project-root",
         "tests/entrypoint-resolution/lib",
         "--no-title",
-        "--no-license"
+        "--no-license",
     ];
 
     Assert::main_binary()
         .with_args(&args)
         .succeeds()
-        .and().stdout().is("lib")
+        .and()
+        .stdout()
+        .is("lib")
         .unwrap();
 }
 
@@ -43,13 +47,15 @@ fn entrypoint_resolution_cargo_lib() {
         "--project-root",
         "tests/entrypoint-resolution/cargo-lib",
         "--no-title",
-        "--no-license"
+        "--no-license",
     ];
 
     Assert::main_binary()
         .with_args(&args)
         .succeeds()
-        .and().stdout().is("cargo lib")
+        .and()
+        .stdout()
+        .is("cargo lib")
         .unwrap();
 }
 
@@ -60,12 +66,14 @@ fn entrypoint_resolution_cargo_bin() {
         "--project-root",
         "tests/entrypoint-resolution/cargo-bin",
         "--no-title",
-        "--no-license"
+        "--no-license",
     ];
 
     Assert::main_binary()
         .with_args(&args)
         .succeeds()
-        .and().stdout().is("cargo bin")
+        .and()
+        .stdout()
+        .is("cargo bin")
         .unwrap();
 }

--- a/tests/multiline-doc.rs
+++ b/tests/multiline-doc.rs
@@ -61,6 +61,8 @@ fn multiline_doc() {
     Assert::main_binary()
         .with_args(&args)
         .succeeds()
-        .and().stdout().is(EXPECTED)
+        .and()
+        .stdout()
+        .is(EXPECTED)
         .unwrap();
 }

--- a/tests/multiple-bin-fail.rs
+++ b/tests/multiple-bin-fail.rs
@@ -11,6 +11,8 @@ fn multiple_bin_fail() {
     Assert::main_binary()
         .with_args(&args)
         .fails()
-        .and().stderr().is(EXPECTED)
+        .and()
+        .stderr()
+        .is(EXPECTED)
         .unwrap();
 }

--- a/tests/no-entrypoint-fail.rs
+++ b/tests/no-entrypoint-fail.rs
@@ -11,6 +11,8 @@ fn no_entrypoint_fail() {
     Assert::main_binary()
         .with_args(&args)
         .fails()
-        .and().stderr().is(EXPECTED)
+        .and()
+        .stderr()
+        .is(EXPECTED)
         .unwrap();
 }

--- a/tests/no-template.rs
+++ b/tests/no-template.rs
@@ -59,6 +59,8 @@ fn no_template() {
     Assert::main_binary()
         .with_args(&args)
         .succeeds()
-        .and().stdout().is(EXPECTED)
+        .and()
+        .stdout()
+        .is(EXPECTED)
         .unwrap();
 }

--- a/tests/project-with-version.rs
+++ b/tests/project-with-version.rs
@@ -21,6 +21,8 @@ fn template_with_version() {
     Assert::main_binary()
         .with_args(&args)
         .succeeds()
-        .and().stdout().is(EXPECTED)
+        .and()
+        .stdout()
+        .is(EXPECTED)
         .unwrap();
 }


### PR DESCRIPTION
The use of rustfmt allow for uniform code formatting across different
developers and helps to allow easier reading of code, as people gets
used to the consistent code style across the whole ecosystem.

Signed-off-by: Otavio Salvador <otavio@ossystems.com.br>