### PR TITLE
Add support for travis-ci.com

### DIFF
--- a/src/config/badges.rs
+++ b/src/config/badges.rs
@@ -69,9 +69,16 @@ pub fn travis_ci(attrs: Attrs) -> String {
         .map(|i| i.as_ref())
         .unwrap_or(BADGE_BRANCH_DEFAULT);
 
+    let url = match &attrs.get("tld").unwrap_or(&"org".to_string())[..] {
+        "com" => "https://travis-ci.com",
+        "org" => "https://travis-ci.org",
+        other => panic!("Invalid travis-ci tld found: allowed: com,org but found: {}", other),
+    };
+
     format!(
-        "[![Build Status](https://travis-ci.org/{repo}.svg?branch={branch})]\
-         (https://travis-ci.org/{repo})",
+        "[![Build Status]({url}/{repo}.svg?branch={branch})]\
+         ({url}/{repo})",
+        url = url,
         repo = repo,
         branch = percent_encode(branch)
     )

--- a/tests/travis-com.rs
+++ b/tests/travis-com.rs
@@ -1,0 +1,26 @@
+extern crate assert_cli;
+
+use assert_cli::Assert;
+
+const EXPECTED: &str = r#"
+[![Build Status](https://travis-ci.com/cargo-readme/test.svg?branch=master)](https://travis-ci.com/cargo-readme/test)
+
+# readme-test
+
+Test crate for cargo-readme
+
+License: MIT
+"#;
+
+#[test]
+fn badges() {
+    let args = ["readme", "--project-root", "tests/travis-com"];
+
+    Assert::main_binary()
+        .with_args(&args)
+        .succeeds()
+        .and()
+        .stdout()
+        .is(EXPECTED)
+        .unwrap();
+}

--- a/tests/travis-com/.gitignore
+++ b/tests/travis-com/.gitignore
@@ -1,0 +1,1 @@
+Cargo.lock

--- a/tests/travis-com/Cargo.toml
+++ b/tests/travis-com/Cargo.toml
@@ -1,0 +1,8 @@
+[package]
+name = "readme-test"
+version = "0.1.0"
+authors = ["Livio Ribeiro <livioribeiro@outlook.com>"]
+license = "MIT"
+
+[badges]
+travis-ci = { repository = "cargo-readme/test", tld = "com" }

--- a/tests/travis-com/README.tpl
+++ b/tests/travis-com/README.tpl
@@ -1,0 +1,7 @@
+{{badges}}
+
+# {{crate}}
+
+{{readme}}
+
+License: {{license}}

--- a/tests/travis-com/src/lib.rs
+++ b/tests/travis-com/src/lib.rs
@@ -1,0 +1,1 @@
+//! Test crate for cargo-readme


### PR DESCRIPTION
As per [this blog post](https://blog.travis-ci.com/2018-05-02-open-source-projects-on-travis-ci-com-with-github-apps): travis-ci is migrating users away from `travis-ci.org` to `travis-ci.com` but this repo only supports the former.

I've added support for an optional key `tld` (with possible values `"org"` or `"com"`) to the travis badge which will generate badge urls for pointing to `.org` or `.com`. Any other value will be a panic.

Open questions:
- Should there be a better mechanism than a panic?
- How does crates.io handle the travis-ci badge, do they have support for `.com`?
- I have not yet updated the docs for this change
- Bikeshed on the key "tld". Should it be added to, e.g. "service" to specify the full url?