### PR TITLE
Add support for Github Workflow badges

### DIFF
--- a/src/config/badges.rs
+++ b/src/config/badges.rs
@@ -4,6 +4,7 @@ use percent_encoding as pe;
 
 const BADGE_BRANCH_DEFAULT: &str = "master";
 const BADGE_SERVICE_DEFAULT: &str = "github";
+const BADGE_WORKFLOW_DEFAULT: &str = "main";
 
 type Attrs = BTreeMap<String, String>;
 
@@ -74,6 +75,22 @@ pub fn travis_ci(attrs: Attrs) -> String {
          (https://travis-ci.org/{repo})",
         repo = repo,
         branch = percent_encode(branch)
+    )
+}
+
+pub fn github(attrs: Attrs) -> String {
+    let repo = &attrs["repository"];
+    let workflow = attrs
+        .get("workflow")
+        .map(|i| i.as_ref())
+        .unwrap_or(BADGE_WORKFLOW_DEFAULT);
+
+    format!(
+        "[![Workflow Status](https://github.com/{repo}/workflows/{workflow}/badge.svg)]\
+         (https://github.com/{repo}/actions?query=workflow%3A%22{workflow_plus}%22)",
+        repo = repo,
+        workflow = percent_encode(workflow),
+        workflow_plus = percent_encode(&str::replace(workflow, " ", "+"))
     )
 }
 

--- a/src/config/manifest.rs
+++ b/src/config/manifest.rs
@@ -86,13 +86,14 @@ fn process_badges(badges: BTreeMap<String, BTreeMap<String, String>>) -> Vec<Str
             "circle-ci" => Some((1, badges::circle_ci(attrs))),
             "gitlab" => Some((2, badges::gitlab(attrs))),
             "travis-ci" => Some((3, badges::travis_ci(attrs))),
-            "codecov" => Some((4, badges::codecov(attrs))),
-            "coveralls" => Some((5, badges::coveralls(attrs))),
+            "github" => Some((4, badges::github(attrs))),
+            "codecov" => Some((5, badges::codecov(attrs))),
+            "coveralls" => Some((6, badges::coveralls(attrs))),
             "is-it-maintained-issue-resolution" => {
-                Some((6, badges::is_it_maintained_issue_resolution(attrs)))
+                Some((7, badges::is_it_maintained_issue_resolution(attrs)))
             }
             "is-it-maintained-open-issues" => {
-                Some((7, badges::is_it_maintained_open_issues(attrs)))
+                Some((8, badges::is_it_maintained_open_issues(attrs)))
             }
             _ => return None,
         })

--- a/src/readme/extract.rs
+++ b/src/readme/extract.rs
@@ -69,7 +69,7 @@ fn extract_docs_multiline_style<R: Read>(
             }
         }
 
-        result.push(line.trim_right().to_owned());
+        result.push(line.trim_end().to_owned());
     }
 
     Ok(result)
@@ -83,7 +83,7 @@ fn normalize_line(mut line: String) -> String {
     } else {
         // if the first character after the comment mark is " ", remove it
         let split_at = if line.find(" ") == Some(3) { 4 } else { 3 };
-        line.split_at(split_at).1.trim_right().to_owned()
+        line.split_at(split_at).1.trim_end().to_owned()
     }
 }
 

--- a/src/readme/template.rs
+++ b/src/readme/template.rs
@@ -51,7 +51,7 @@ fn process_template(
     license: Option<&str>,
     version: &str,
 ) -> Result<String, String> {
-    template = template.trim_right_matches("\n").to_owned();
+    template = template.trim_end_matches("\n").to_owned();
 
     if !template.contains("{{readme}}") {
         return Err("Missing `{{readme}}` in template".to_owned());


### PR DESCRIPTION
Since Github Actions are now out of beta, cargo-readme should be able to add badges to show the status of workflows. This PR implements this for the default branch of a given repository.