### PR TITLE
WIP: Init of --force flag

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -74,7 +74,10 @@ fn main() {
                 .long("no-indent-headings")
                 .help("Do not add an extra level to headings.{n}\
                        By default, '#' headings become '##', so the first '#' can be the crate \
-                       name. Use this option to prevent this behavior.")))
+                       name. Use this option to prevent this behavior."))
+            .arg(Arg::with_name("FORCE")
+                .long("force")
+                .help("Return warning instead of error whenever possible.")))
         .get_matches();
 
     if let Some(m) = matches.subcommand_matches("readme") {
@@ -101,6 +104,7 @@ fn execute(m: &ArgMatches) -> Result<(), String> {
     let add_license = !m.is_present("NO_LICENSE");
     let no_template = m.is_present("NO_TEMPLATE");
     let indent_headings = !m.is_present("NO_INDENT_HEADINGS");
+    let force = m.is_present("FORCE");
 
     // get project root
     let project_root = helper::get_project_root(m.value_of("ROOT"))?;
@@ -127,6 +131,7 @@ fn execute(m: &ArgMatches) -> Result<(), String> {
         add_badges,
         add_license,
         indent_headings,
+        force,
     )?;
 
     helper::write_output(&mut dest, readme)

--- a/src/readme/mod.rs
+++ b/src/readme/mod.rs
@@ -18,6 +18,7 @@ pub fn generate_readme<T: Read>(
     add_badges: bool,
     add_license: bool,
     indent_headings: bool,
+    force: bool,
 ) -> Result<String, String> {
     let lines = extract::extract_docs(source).map_err(|e| format!("{}", e))?;
 
@@ -33,7 +34,15 @@ pub fn generate_readme<T: Read>(
     // get manifest from Cargo.toml
     let cargo = config::get_manifest(project_root)?;
 
-    template::render(template, readme, &cargo, add_title, add_badges, add_license)
+    template::render(
+        template,
+        readme,
+        &cargo,
+        add_title,
+        add_badges,
+        add_license,
+        force,
+    )
 }
 
 /// Load a template String from a file


### PR DESCRIPTION
This draft add `--force` flag. At this moment it allow generate `README.md` from `README.tpl` that contains `{{badges}}` or `{{license}}` without corresponding fields in `Cargo.toml`

Closes #42 