### PR TITLE
Fix typo in maintenance badge "activly" -> "actively"

### DIFF
--- a/src/config/badges.rs
+++ b/src/config/badges.rs
@@ -161,7 +161,7 @@ pub fn maintenance(attrs: Attrs) -> String {
 
     // https://github.com/rust-lang/crates.io/blob/5a08887d4b531e034d01386d3e5997514f3c8ee5/src/models/badge.rs#L82
     let status_with_color = match status.as_ref() {
-        "actively-developed" => "activly--developed-brightgreen",
+        "actively-developed" => "actively--developed-brightgreen",
         "passively-maintained" => "passively--maintained-yellowgreen",
         "as-is" => "as--is-yellow",
         "none" => "maintenance-none-lightgrey", // color is a guess


### PR DESCRIPTION
![](https://img.shields.io/badge/maintenance-activly--developed-brightgreen.svg)

vs

![](https://img.shields.io/badge/maintenance-actively--developed-brightgreen.svg)