### PR TITLE
Fix CI breakage due to compile-time warning

### DIFF
--- a/src/readme/extract.rs
+++ b/src/readme/extract.rs
@@ -60,8 +60,7 @@ fn extract_docs_multiline_style<R: Read>(
         if let Some(pos) = line.rfind("*/") {
             nesting -= line.matches("*/").count() as isize;
             if nesting < 0 {
-                let mut line = line;
-                line.split_off(pos);
+                let line = line[0..pos].to_string();
                 if !line.trim().is_empty() {
                     result.push(line);
                 }


### PR DESCRIPTION
tests/multiple-bin-fail.rs ends up running the binary with
"cargo run" so its warning output ends up getting collected in
the test case. When it examines the subprocess's stderr, it fails the
assertion because the compiler warning is included in it.