### PR TITLE
add release action

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,33 @@
+name: release
+
+on:
+  push:
+    branches: [ master ]
+    tags: [ '*.*.*' ]
+
+jobs:
+  release-crates:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Publish package to crates
+        run: |
+          cargo package
+          cargo publish --token ${{ secrets.CARGO_TOKEN }}
+
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Build
+        run: cargo build --release
+      - name: Archive
+        run: |
+          GIT_TAG=$(git describe --tags `git rev-list --tags --max-count=1`)
+          tar -C target/release -czf $(pwd)/cargo-readme-${GIT_TAG}.tar.gz cargo-readme
+      - name: Publish release
+        uses: softprops/action-gh-release@v1
+        with:
+          files: cargo-readme-*.tar.gz
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Closes #31
_Requires secrets from the repo (crates.io and github tokens)_

### Description
Add a release workflow so that every time a tag is pushed to the repository, a release is produced. Additionally, it is published to crates.io. The action is taken from [tarpaulin](https://github.com/xd009642/tarpaulin/blob/develop/.github/workflows/release.yml) and it would end up looking like [this](https://github.com/xd009642/tarpaulin/releases/tag/0.16.0).

### Purpose
Pure convenience. In order to integrate it with github workflows (see example [here](https://github.com/carrascomj/rust_sbml/blob/trunk/.github/workflows/readme.yml)), it would be very nice to have up-to-date binaries so that we don't have to `cargo install`. That also would allow for building a cool action like the ones from [actions-rs](https://github.com/actions-rs/).