### PR TITLE
added crates-io support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,3 +23,4 @@ assert_cli = "0.6"
 
 [badges]
 github = { repository = "livioribeiro/cargo-readme" }
+crates-io = { crate = "cargo-readme" }

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
-[![Crates.io](https://img.shields.io/crates/v/cargo-readme.svg)](https://crates.io/crates/cargo-readme)
 [![Workflow Status](https://github.com/livioribeiro/cargo-readme/workflows/main/badge.svg)](https://github.com/livioribeiro/cargo-readme/actions?query=workflow%3A%22main%22)
+![crates-io](https://img.shields.io/crates/v/cargo-readme.svg)
 
 # cargo-readme
 

--- a/README.tpl
+++ b/README.tpl
@@ -1,4 +1,3 @@
-[![Crates.io](https://img.shields.io/crates/v/cargo-readme.svg)](https://crates.io/crates/cargo-readme)
 {{badges}}
 
 # {{crate}}

--- a/src/config/badges.rs
+++ b/src/config/badges.rs
@@ -178,6 +178,16 @@ pub fn maintenance(attrs: Attrs) -> String {
     )
 }
 
+pub fn crates_io(attrs: Attrs) -> String {
+    // XXX should add support for version-sync
+    // "![crates-io](https://img.shields.io/crates/v/version-sync.svg)"
+    let crate_name = &attrs["crate"];
+    format!(
+        "![crates-io](https://img.shields.io/crates/v/{crate_name}.svg)",
+        crate_name = crate_name
+    )
+}
+
 fn percent_encode(input: &str) -> pe::PercentEncode {
     pe::utf8_percent_encode(input, pe::NON_ALPHANUMERIC)
 }

--- a/src/config/manifest.rs
+++ b/src/config/manifest.rs
@@ -95,7 +95,8 @@ fn process_badges(badges: BTreeMap<String, BTreeMap<String, String>>) -> Vec<Str
             "is-it-maintained-open-issues" => {
                 Some((8, badges::is_it_maintained_open_issues(attrs)))
             }
-            "maintenance" => Some((9, badges::maintenance(attrs))),
+            "crates-io" => Some((9, badges::crates_io(attrs))),
+            "maintenance" => Some((10, badges::maintenance(attrs))),
             _ => return None,
         })
         .collect();

--- a/src/readme/extract.rs
+++ b/src/readme/extract.rs
@@ -61,7 +61,7 @@ fn extract_docs_multiline_style<R: Read>(
             nesting -= line.matches("*/").count() as isize;
             if nesting < 0 {
                 let mut line = line;
-                line.split_off(pos);
+                let _ = line.split_off(pos);
                 if !line.trim().is_empty() {
                     result.push(line);
                 }


### PR DESCRIPTION
This PR enables the `crates-io` badge  with keyword `crate`in `Cargo.toml`.

Closes Issue #40.