### PR TITLE
Detect empty lines starting with a sharp in code blocks

### DIFF
--- a/src/readme/extract.rs
+++ b/src/readme/extract.rs
@@ -60,8 +60,7 @@ fn extract_docs_multiline_style<R: Read>(
         if let Some(pos) = line.rfind("*/") {
             nesting -= line.matches("*/").count() as isize;
             if nesting < 0 {
-                let mut line = line;
-                line.split_off(pos);
+                let line = line[0..pos].to_string();
                 if !line.trim().is_empty() {
                     result.push(line);
                 }

--- a/src/readme/process.rs
+++ b/src/readme/process.rs
@@ -45,7 +45,7 @@ impl Processor {
 
     pub fn process_line(&mut self, mut line: String) -> Option<String> {
         // Skip lines that should be hidden in docs
-        if self.section == Section::CodeRust && line.starts_with("# ") {
+        if self.section == Section::CodeRust && (line.starts_with("# ") || line == "#") {
             return None;
         }
 
@@ -104,6 +104,7 @@ mod tests {
         "```",
         "#[visible]",
         "let visible = \"visible\";",
+        "#",
         "# let hidden = \"hidden\";",
         "```",
     ];


### PR DESCRIPTION
Based on #52

Fixes #38