### PR TITLE
Fix coveralls badge config

### DIFF
--- a/src/config/badges.rs
+++ b/src/config/badges.rs
@@ -130,7 +130,7 @@ pub fn coveralls(attrs: Attrs) -> String {
         .unwrap_or(BADGE_SERVICE_DEFAULT);
 
     format!(
-        "[![Coverage Status](https://coveralls.io/repos/{service}/{repo}/badge.svg?branch=branch)]\
+        "[![Coverage Status](https://coveralls.io/repos/{service}/{repo}/badge.svg?branch={branch})]\
          (https://coveralls.io/{service}/{repo}?branch={branch})",
         repo = repo,
         branch = percent_encode(branch),

--- a/src/readme/extract.rs
+++ b/src/readme/extract.rs
@@ -61,7 +61,7 @@ fn extract_docs_multiline_style<R: Read>(
             nesting -= line.matches("*/").count() as isize;
             if nesting < 0 {
                 let mut line = line;
-                line.split_off(pos);
+                line.truncate(pos);
                 if !line.trim().is_empty() {
                     result.push(line);
                 }

--- a/tests/badges.rs
+++ b/tests/badges.rs
@@ -8,7 +8,7 @@ const EXPECTED: &str = r#"
 [![Build Status](https://gitlab.com/cargo-readme/test/badges/master/pipeline.svg)](https://gitlab.com/cargo-readme/test/commits/master)
 [![Build Status](https://travis-ci.org/cargo-readme/test.svg?branch=master)](https://travis-ci.org/cargo-readme/test)
 [![Coverage Status](https://codecov.io/gh/cargo-readme/test/branch/master/graph/badge.svg)](https://codecov.io/gh/cargo-readme/test)
-[![Coverage Status](https://coveralls.io/repos/github/cargo-readme/test/badge.svg?branch=branch)](https://coveralls.io/github/cargo-readme/test?branch=master)
+[![Coverage Status](https://coveralls.io/repos/github/cargo-readme/test/badge.svg?branch=master)](https://coveralls.io/github/cargo-readme/test?branch=master)
 [![Average time to resolve an issue](https://isitmaintained.com/badge/resolution/cargo-readme/test.svg)](https://isitmaintained.com/project/cargo-readme/test "Average time to resolve an issue")
 [![Percentage of issues still open](https://isitmaintained.com/badge/open/cargo-readme/test.svg)](https://isitmaintained.com/project/cargo-readme/test "Percentage of issues still open")
 


### PR DESCRIPTION
This PR:

*  https://github.com/livioribeiro/cargo-readme/commit/d2db80b48890a143d9d5639c198c9ce3a31e6ba2 replaces [`String::split_off(usize)`](https://doc.rust-lang.org/src/alloc/string.rs.html#1443) with `String::truncate(usize)` as its returned value is unused so that the tests `no_entrypoint_fail` and `multiple_bin_fail` have the expected output.

* https://github.com/livioribeiro/cargo-readme/commit/6fed7ed15d6c72c795881c3411f4c2492c0f5e86 fixes the coveralls badge config so it uses the configured branch in the `branch` attribute.

Thanks for this crate! 🥳 
