### PR TITLE
Fix all current clippy warnings

### DIFF
--- a/src/config/manifest.rs
+++ b/src/config/manifest.rs
@@ -44,20 +44,17 @@ impl Manifest {
         Manifest {
             name: cargo_toml.package.name,
             license: cargo_toml.package.license,
-            lib: cargo_toml.lib.map(|lib| ManifestLib::from_cargo_toml(lib)),
+            lib: cargo_toml.lib.map(ManifestLib::from_cargo_toml),
             bin: cargo_toml
                 .bin
                 .map(|bin_vec| {
                     bin_vec
                         .into_iter()
-                        .map(|bin| ManifestLib::from_cargo_toml(bin))
+                        .map(ManifestLib::from_cargo_toml)
                         .collect()
                 })
                 .unwrap_or_default(),
-            badges: cargo_toml
-                .badges
-                .map(|b| process_badges(b))
-                .unwrap_or_default(),
+            badges: cargo_toml.badges.map(process_badges).unwrap_or_default(),
             version: cargo_toml.package.version,
         }
     }
@@ -96,7 +93,7 @@ fn process_badges(badges: BTreeMap<String, BTreeMap<String, String>>) -> Vec<Str
                 Some((8, badges::is_it_maintained_open_issues(attrs)))
             }
             "maintenance" => Some((9, badges::maintenance(attrs))),
-            _ => return None,
+            _ => None,
         })
         .collect();
 

--- a/src/config/project.rs
+++ b/src/config/project.rs
@@ -63,11 +63,11 @@ pub fn find_entrypoint(current_dir: &Path, manifest: &Manifest) -> Result<PathBu
     }
 
     // try bin defined in `Cargo.toml`
-    if manifest.bin.len() > 0 {
+    if !manifest.bin.is_empty() {
         let mut bin_list: Vec<_> = manifest
             .bin
             .iter()
-            .filter(|b| b.doc == true)
+            .filter(|b| b.doc)
             .map(|b| b.path.clone())
             .collect();
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -78,14 +78,11 @@ fn main() {
         .get_matches();
 
     if let Some(m) = matches.subcommand_matches("readme") {
-        match execute(m) {
-            Err(e) => {
-                io::stderr()
-                    .write_fmt(format_args!("Error: {}\n", e))
-                    .expect("An error occurred while trying to show an error message");
-                std::process::exit(1);
-            }
-            _ => {}
+        if let Err(e) = execute(m) {
+            io::stderr()
+                .write_fmt(format_args!("Error: {}\n", e))
+                .expect("An error occurred while trying to show an error message");
+            std::process::exit(1);
         }
     }
 }

--- a/src/readme/extract.rs
+++ b/src/readme/extract.rs
@@ -33,7 +33,7 @@ fn extract_docs_singleline_style<R: Read>(
 
         if line.starts_with("//!") {
             result.push(normalize_line(line));
-        } else if line.trim().len() > 0 {
+        } else if !line.trim().is_empty() {
             // doc ends, code starts
             break;
         }
@@ -61,7 +61,7 @@ fn extract_docs_multiline_style<R: Read>(
             nesting -= line.matches("*/").count() as isize;
             if nesting < 0 {
                 let mut line = line;
-                line.split_off(pos);
+                let _ = line.split_off(pos);
                 if !line.trim().is_empty() {
                     result.push(line);
                 }
@@ -82,7 +82,7 @@ fn normalize_line(mut line: String) -> String {
         line
     } else {
         // if the first character after the comment mark is " ", remove it
-        let split_at = if line.find(" ") == Some(3) { 4 } else { 3 };
+        let split_at = if line.find(' ') == Some(3) { 4 } else { 3 };
         line.split_at(split_at).1.trim_end().to_owned()
     }
 }

--- a/src/readme/mod.rs
+++ b/src/readme/mod.rs
@@ -39,9 +39,8 @@ pub fn generate_readme<T: Read>(
 /// Load a template String from a file
 fn get_template_string<T: Read>(template: &mut T) -> Result<String, String> {
     let mut template_string = String::new();
-    match template.read_to_string(&mut template_string) {
-        Err(e) => return Err(format!("Error: {}", e)),
-        _ => {}
+    if let Err(e) = template.read_to_string(&mut template_string) {
+        return Err(format!("Error: {}", e));
     }
 
     Ok(template_string)

--- a/src/readme/process.rs
+++ b/src/readme/process.rs
@@ -8,7 +8,7 @@ use std::iter::{IntoIterator, Iterator};
 
 use regex::Regex;
 
-lazy_static!{
+lazy_static! {
     // Is this code block rust?
     static ref RE_CODE_RUST: Regex = Regex::new(r"^(?P<delimiter>`{3,4}|~{3,4})(?:rust|(?:(?:rust,)?(?:no_run|ignore|should_panic)))?$").unwrap();
     // Is this code block just text?
@@ -38,7 +38,7 @@ impl Processor {
     pub fn new(indent_headings: bool) -> Self {
         Processor {
             section: Section::None,
-            indent_headings: indent_headings,
+            indent_headings,
             delimiter: None,
         }
     }
@@ -50,7 +50,7 @@ impl Processor {
         }
 
         // indent heading when outside code
-        if self.indent_headings && self.section == Section::None && line.starts_with("#") {
+        if self.indent_headings && self.section == Section::None && line.starts_with('#') {
             line.insert(0, '#');
         } else if self.section == Section::None {
             let l = line.clone();
@@ -68,7 +68,7 @@ impl Processor {
             }
         } else if self.section != Section::None && Some(&line) == self.delimiter.as_ref() {
             self.section = Section::None;
-            line = self.delimiter.take().unwrap_or("```".to_owned());
+            line = self.delimiter.take().unwrap_or_else(|| "```".to_owned());
         }
 
         Some(line)

--- a/src/readme/template.rs
+++ b/src/readme/template.rs
@@ -51,19 +51,21 @@ fn process_template(
     license: Option<&str>,
     version: &str,
 ) -> Result<String, String> {
-    template = template.trim_end_matches("\n").to_owned();
+    template = template.trim_end_matches('\n').to_owned();
 
     if !template.contains("{{readme}}") {
         return Err("Missing `{{readme}}` in template".to_owned());
     }
 
     if template.contains("{{crate}}") {
-        template = template.replace("{{crate}}", &title);
+        template = template.replace("{{crate}}", title);
     }
 
     if template.contains("{{badges}}") {
         if badges.is_empty() {
-            return Err("`{{badges}}` was found in template but no badges were provided".to_owned());
+            return Err(
+                "`{{badges}}` was found in template but no badges were provided".to_owned(),
+            );
         }
         let badges = badges.join("\n");
         template = template.replace("{{badges}}", &badges);
@@ -71,7 +73,7 @@ fn process_template(
 
     if template.contains("{{license}}") {
         if let Some(license) = license {
-            template = template.replace("{{license}}", &license);
+            template = template.replace("{{license}}", license);
         } else {
             return Err(
                 "`{{license}}` was found in template but no license was provided".to_owned(),
@@ -114,7 +116,7 @@ fn process_string(
 
 /// Prepend badges to output string
 fn prepend_badges(readme: String, badges: &[&str]) -> String {
-    if badges.len() > 0 {
+    if !badges.is_empty() {
         let badges = badges.join("\n");
         if !readme.is_empty() {
             format!("{}\n\n{}", badges, readme)


### PR DESCRIPTION
- Call function directly in .map
- Use .is_empty
- Remove redundant "return"
- Remove unnecessary references
- etc.