### PR TITLE
Add every rustdoc language annotation

### DIFF
--- a/src/readme/process.rs
+++ b/src/readme/process.rs
@@ -10,7 +10,7 @@ use regex::Regex;
 
 lazy_static!{
     // Is this code block rust?
-    static ref RE_CODE_RUST: Regex = Regex::new(r"^(?P<delimiter>`{3,4}|~{3,4})(?:rust|(?:(?:rust,)?(?:no_run|ignore|should_panic)))?$").unwrap();
+    static ref RE_CODE_RUST: Regex = Regex::new(r"^(?P<delimiter>`{3,4}|~{3,4})(?:rust|(?:(?:rust,)?(?:should_panic|should-panic|shouldpanic|no_run|no-run|norun|ignore|ignore-.*|test_harness|test-harness|testharness|compile_fail|compile-fail|compilefail|edition....|E....)))?$").unwrap();
     // Is this code block just text?
     static ref RE_CODE_TEXT: Regex = Regex::new(r"^(?P<delimiter>`{3,4}|~{3,4})text$").unwrap();
     // Is this code block a language other than rust?


### PR DESCRIPTION
This adds support for [every language annotation that rustdoc recognizes](https://github.com/rust-lang/rust/blob/7ac4b82ddd596a218cac8cd6b88a91b54fcdcf13/src/librustdoc/html/markdown.rs#L848)
```
should_panic   
should-panic   <- new  
shouldpanic    <- new 
no_run         
no-run         <- new      
norun          <- new
ignore         
ignore-.*      <- new
rust           
test_harness   <- new  
test-harness   <- new  
testharness    <- new 
compile_fail   <- new
compile-fail   <- new
compilefail    <- new
edition....    <- new
E....          <- new    
```
The only change that was needed was to modify the regex that recognized if a code block is rust code

The new regex works on this input:
### test file
```
//! should_panic:
//! ```should_panic
//! let a = 3;
//! ```
//! should-panic:
//! ```should-panic
//! let a = 3;
//! ```
//! shouldpanic:
//! ```shouldpanic
//! let a = 3;
//! ```
//! no_run:
//! ```no_run
//! let a = 3;
//! ```
//! no-run:
//! ```no-run
//! let a = 3;
//! ```
//! norun:
//! ```norun
//! let a = 3;
//! ```
//! ignore:
//! ```ignore
//! let a = 3;
//! ```
//! ignore-on-some-hardware:
//! ```ignore-on-some-hardware
//! let a = 3;
//! ```
//! rust:
//! ```rust
//! let a = 3;
//! ```
//! test_harness:
//! ```test_harness
//! let a = 3;
//! ```
//! test-harness:
//! ```test-harness
//! let a = 3;
//! ```
//! testharness:
//! ```testharness
//! let a = 3;
//! ```
//! compile_fail:
//! ```compile_fail
//! let a = 3;
//! ```
//! compile-fail:
//! ```compile-fail
//! let a = 3;
//! ```
//! compilefail:
//! ```compilefail
//! let a = 3;
//! ```
//! edition2015
//! ```edition2015
//! let a = 3;
//! ```
//! E1234:
//! ```E1234
//! let a = 3;
//! ```
```
### output

should_panic:
```rust
let a = 3;
```
should-panic:
```rust
let a = 3;
```
shouldpanic:
```rust
let a = 3;
```
no_run:
```rust
let a = 3;
```
no-run:
```rust
let a = 3;
```
norun:
```rust
let a = 3;
```
ignore:
```rust
let a = 3;
```
ignore-on-some-hardware:
```rust
let a = 3;
```
rust:
```rust
let a = 3;
```
test_harness:
```rust
let a = 3;
```
test-harness:
```rust
let a = 3;
```
testharness:
```rust
let a = 3;
```
compile_fail:
```rust
let a = 3;
```
compile-fail:
```rust
let a = 3;
```
compilefail:
```rust
let a = 3;
```
edition2015
```rust
let a = 3;
```
E1234:
```rust
let a = 3;
```
