### PR TITLE
Support cargo workspace inheritance

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -110,12 +110,23 @@ name = "cargo-readme"
 version = "3.3.2"
 dependencies = [
  "assert_cli",
+ "cargo_toml",
  "clap",
  "lazy_static",
  "percent-encoding",
  "regex",
  "serde",
- "toml",
+ "toml 1.1.2+spec-1.1.0",
+]
+
+[[package]]
+name = "cargo_toml"
+version = "0.17.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a969e13a7589e9e3e4207e153bae624ade2b5622fb4684a4923b23ec3d57719"
+dependencies = [
+ "serde",
+ "toml 0.8.23",
 ]
 
 [[package]]
@@ -424,6 +435,15 @@ dependencies = [
 
 [[package]]
 name = "serde_spanned"
+version = "0.6.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf41e0cfaf7226dca15e8197172c295a782857fcb97fad1808a166870dee75a3"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "serde_spanned"
 version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6662b5879511e06e8999a8a235d848113e942c9124f211511b16466ee2995f26"
@@ -473,17 +493,38 @@ dependencies = [
 
 [[package]]
 name = "toml"
+version = "0.8.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc1beb996b9d83529a9e75c17a1686767d148d70663143c7854d8b4a09ced362"
+dependencies = [
+ "serde",
+ "serde_spanned 0.6.9",
+ "toml_datetime 0.6.11",
+ "toml_edit",
+]
+
+[[package]]
+name = "toml"
 version = "1.1.2+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "81f3d15e84cbcd896376e6730314d59fb5a87f31e4b038454184435cd57defee"
 dependencies = [
  "indexmap",
  "serde_core",
- "serde_spanned",
- "toml_datetime",
+ "serde_spanned 1.1.1",
+ "toml_datetime 1.1.1+spec-1.1.0",
  "toml_parser",
  "toml_writer",
- "winnow",
+ "winnow 1.0.1",
+]
+
+[[package]]
+name = "toml_datetime"
+version = "0.6.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22cddaf88f4fbc13c51aebbf5f8eceb5c7c5a9da2ac40a13519eb5b0a0e8f11c"
+dependencies = [
+ "serde",
 ]
 
 [[package]]
@@ -496,13 +537,33 @@ dependencies = [
 ]
 
 [[package]]
+name = "toml_edit"
+version = "0.22.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41fe8c660ae4257887cf66394862d21dbca4a6ddd26f04a3560410406a2f819a"
+dependencies = [
+ "indexmap",
+ "serde",
+ "serde_spanned 0.6.9",
+ "toml_datetime 0.6.11",
+ "toml_write",
+ "winnow 0.7.15",
+]
+
+[[package]]
 name = "toml_parser"
 version = "1.1.2+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2abe9b86193656635d2411dc43050282ca48aa31c2451210f4202550afb7526"
 dependencies = [
- "winnow",
+ "winnow 1.0.1",
 ]
+
+[[package]]
+name = "toml_write"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d99f8c9a7727884afe522e9bd5edbfc91a3312b36a77b5fb8926e4c31a41801"
 
 [[package]]
 name = "toml_writer"
@@ -563,6 +624,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
 dependencies = [
  "windows-link",
+]
+
+[[package]]
+name = "winnow"
+version = "0.7.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df79d97927682d2fd8adb29682d1140b343be4ac0f08fd68b7765d9c059d3945"
+dependencies = [
+ "memchr",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,7 @@ regex = "1"
 serde = { version = "1", features = ["derive"] }
 percent-encoding = "2"
 lazy_static = "1"
+cargo_toml = "0.17"
 
 [dev-dependencies]
 assert_cli = "0.6"

--- a/src/config/manifest.rs
+++ b/src/config/manifest.rs
@@ -2,30 +2,24 @@
 
 use serde::Deserialize;
 use std::collections::BTreeMap;
-use std::fs::File;
-use std::io::Read;
 use std::path::{Path, PathBuf};
 
 use super::badges;
 
 /// Try to get manifest info from Cargo.toml
 pub fn get_manifest(project_root: &Path) -> Result<Manifest, String> {
-    let mut cargo_toml = File::open(project_root.join("Cargo.toml"))
+    let cargo_toml_path = project_root.join("Cargo.toml");
+
+    // Use cargo_toml crate for workspace inheritance support
+    let manifest = cargo_toml::Manifest::from_path(&cargo_toml_path)
+        .map_err(|e| format!("{}", e))?;
+
+    // Also parse raw TOML for badges (cargo_toml crate doesn't support all badge types)
+    let raw_toml = std::fs::read_to_string(&cargo_toml_path)
         .map_err(|e| format!("Could not read Cargo.toml: {}", e))?;
+    let raw: RawCargoToml = toml::from_str(&raw_toml).map_err(|e| format!("{}", e))?;
 
-    let buf = {
-        let mut buf = String::new();
-        cargo_toml
-            .read_to_string(&mut buf)
-            .map_err(|e| format!("{}", e))?;
-        buf
-    };
-
-    let cargo_toml: CargoToml = toml::from_str(&buf).map_err(|e| format!("{}", e))?;
-
-    let manifest = Manifest::new(cargo_toml);
-
-    Ok(manifest)
+    Manifest::try_new(manifest, raw.badges)
 }
 
 #[derive(Debug)]
@@ -39,23 +33,48 @@ pub struct Manifest {
 }
 
 impl Manifest {
-    fn new(cargo_toml: CargoToml) -> Manifest {
-        Manifest {
-            name: cargo_toml.package.name,
-            license: cargo_toml.package.license,
-            lib: cargo_toml.lib.map(ManifestLib::from_cargo_toml),
-            bin: cargo_toml
-                .bin
-                .map(|bin_vec| {
-                    bin_vec
-                        .into_iter()
-                        .map(ManifestLib::from_cargo_toml)
-                        .collect()
-                })
-                .unwrap_or_default(),
-            badges: cargo_toml.badges.map(process_badges).unwrap_or_default(),
-            version: cargo_toml.package.version,
-        }
+    fn try_new(
+        manifest: cargo_toml::Manifest,
+        badges: Option<BTreeMap<String, BTreeMap<String, String>>>,
+    ) -> Result<Manifest, String> {
+        let package = manifest
+            .package
+            .ok_or_else(|| "Missing [package] section in Cargo.toml".to_string())?;
+
+        let license = match package.license {
+            Some(license) => match license.get() {
+                Ok(license) => Some(license.to_owned()),
+                Err(_) => {
+                    return Err(
+                        "Could not resolve workspace-inherited license".to_string()
+                    )
+                }
+            },
+            None => None,
+        };
+
+        let lib = ManifestLib::from_product(manifest.lib.as_ref());
+
+        let bin = manifest
+            .bin
+            .iter()
+            .filter_map(|bin| ManifestLib::from_product(Some(bin)))
+            .collect::<Vec<_>>();
+
+        let version = package
+            .version
+            .get()
+            .map_err(|_| "Could not resolve workspace-inherited version".to_string())?
+            .to_owned();
+
+        Ok(Manifest {
+            name: package.name,
+            license,
+            lib,
+            bin,
+            badges: badges.map(process_badges).unwrap_or_default(),
+            version,
+        })
     }
 }
 
@@ -66,10 +85,19 @@ pub struct ManifestLib {
 }
 
 impl ManifestLib {
-    fn from_cargo_toml(lib: CargoTomlLib) -> Self {
-        ManifestLib {
-            path: PathBuf::from(lib.path),
-            doc: lib.doc.unwrap_or(true),
+    fn from_product(product: Option<&cargo_toml::Product>) -> Option<Self> {
+        if let Some(cargo_toml::Product {
+            path: Some(path),
+            doc,
+            ..
+        }) = product
+        {
+            Some(ManifestLib {
+                path: path.into(),
+                doc: *doc,
+            })
+        } else {
+            None
         }
     }
 }
@@ -100,26 +128,8 @@ fn process_badges(badges: BTreeMap<String, BTreeMap<String, String>>) -> Vec<Str
     b.into_iter().map(|(_, badge)| badge).collect()
 }
 
-/// Cargo.toml crate information
-#[derive(Clone, Deserialize)]
-struct CargoToml {
-    pub package: CargoTomlPackage,
-    pub lib: Option<CargoTomlLib>,
-    pub bin: Option<Vec<CargoTomlLib>>,
-    pub badges: Option<BTreeMap<String, BTreeMap<String, String>>>,
-}
-
-/// Cargo.toml crate package information
-#[derive(Clone, Deserialize)]
-struct CargoTomlPackage {
-    pub name: String,
-    pub license: Option<String>,
-    pub version: String,
-}
-
-/// Cargo.toml crate lib information
-#[derive(Clone, Deserialize)]
-struct CargoTomlLib {
-    pub path: String,
-    pub doc: Option<bool>,
+/// Used for extracting badges from raw TOML (cargo_toml crate doesn't support all badge types)
+#[derive(Deserialize)]
+struct RawCargoToml {
+    badges: Option<BTreeMap<String, BTreeMap<String, String>>>,
 }

--- a/tests/workspace.rs
+++ b/tests/workspace.rs
@@ -1,0 +1,39 @@
+use assert_cli::Assert;
+
+const EXPECTED_CRATE1: &str = r#"
+# crate1
+
+Test crate for cargo-readme
+"#;
+
+const EXPECTED_CRATE2: &str = r#"
+# crate2
+
+Test crate for cargo-readme
+"#;
+
+#[test]
+fn workspace_crate1() {
+    let args = ["readme", "--project-root", "tests/workspace/crate1"];
+
+    Assert::main_binary()
+        .with_args(&args)
+        .succeeds()
+        .and()
+        .stdout()
+        .is(EXPECTED_CRATE1)
+        .unwrap();
+}
+
+#[test]
+fn workspace_crate2() {
+    let args = ["readme", "--project-root", "tests/workspace/crate2"];
+
+    Assert::main_binary()
+        .with_args(&args)
+        .succeeds()
+        .and()
+        .stdout()
+        .is(EXPECTED_CRATE2)
+        .unwrap();
+}

--- a/tests/workspace/Cargo.toml
+++ b/tests/workspace/Cargo.toml
@@ -1,0 +1,11 @@
+[workspace]
+members = ["crate1", "crate2"]
+
+[workspace.package]
+edition = "2021"
+version = "0.1.0"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[workspace.dependencies]
+serde = "^1.0"

--- a/tests/workspace/crate1/Cargo.toml
+++ b/tests/workspace/crate1/Cargo.toml
@@ -1,0 +1,9 @@
+[package]
+name = "crate1"
+version.workspace = true
+edition.workspace = true
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+serde = { workspace = true }

--- a/tests/workspace/crate1/src/lib.rs
+++ b/tests/workspace/crate1/src/lib.rs
@@ -1,0 +1,1 @@
+//! Test crate for cargo-readme

--- a/tests/workspace/crate2/Cargo.toml
+++ b/tests/workspace/crate2/Cargo.toml
@@ -1,0 +1,9 @@
+[package]
+name = "crate2"
+version.workspace = true
+edition.workspace = true
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+serde = { workspace = true }

--- a/tests/workspace/crate2/src/lib.rs
+++ b/tests/workspace/crate2/src/lib.rs
@@ -1,0 +1,1 @@
+//! Test crate for cargo-readme


### PR DESCRIPTION
Related https://github.com/webern/cargo-readme/issues/81.

I rewrite using [cargo_toml](https://crates.io/crates/cargo_toml) crate for workspace inheritance.
