### PR TITLE
Add --no-comment-extraction option

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,6 +145,19 @@ License: MY_LICENSE
 By default, `README.tpl` will be used as the template, but you can override it using the
 `--template` to choose a different template or `--no-template` to disable it.
 
+## Reusing a Markdown file as documentation
+
+Rustdoc can pull a crate's documentation straight from a Markdown file:
+
+```rust
+#![doc = include_str!("README.rustdoc.md")]
+```
+
+Point `cargo readme` at that same file with `--no-comment-extraction` and it will process the
+Markdown as-is instead of scanning for doc comments, so a single source produces both the
+rendered crate docs and the repository `README.md`. Hidden doctest lines (starting with `# `)
+are still stripped, so examples stay runnable in `cargo test` yet read cleanly on GitHub.
+
 ## License
 
 Licensed under either of

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -141,6 +141,19 @@
 //!
 //! By default, `README.tpl` will be used as the template, but you can override it using the
 //! `--template` to choose a different template or `--no-template` to disable it.
+//!
+//! # Reusing a Markdown file as documentation
+//!
+//! Rustdoc can pull a crate's documentation straight from a Markdown file:
+//!
+//! ```rust,ignore
+//! #![doc = include_str!("README.rustdoc.md")]
+//! ```
+//!
+//! Point `cargo readme` at that same file with `--no-comment-extraction` and it will process the
+//! Markdown as-is instead of scanning for doc comments, so a single source produces both the
+//! rendered crate docs and the repository `README.md`. Hidden doctest lines (starting with `# `)
+//! are still stripped, so examples stay runnable in `cargo test` yet read cleanly on GitHub.
 
 mod config;
 mod readme;

--- a/src/main.rs
+++ b/src/main.rs
@@ -64,6 +64,12 @@ struct ReadmeArgs {
     #[clap(long)]
     no_title: bool,
 
+    /// Do not extract docs from comment. Instead, just process the input file
+    /// as it is.
+    /// By default, this flag is `false`.
+    #[clap(long)]
+    no_comment_extraction: bool,
+
     /// File to read from.
     /// If not provided, will try to use `src/lib.rs`, then `src/main.rs`. If neither file
     /// could be found, will look into `Cargo.toml` for a `[lib]`, then for a single `[[bin]]`.
@@ -108,6 +114,7 @@ fn execute(args: &ReadmeArgs) -> Result<(), String> {
     let add_badges = !args.no_badges;
     let add_license = !args.no_license;
     let indent_headings = !args.no_indent_headings;
+    let extract_from_comment = !args.no_comment_extraction;
 
     // generate output
     let readme = cargo_readme::generate_readme(
@@ -118,6 +125,7 @@ fn execute(args: &ReadmeArgs) -> Result<(), String> {
         add_badges,
         add_license,
         indent_headings,
+        extract_from_comment,
     )?;
 
     helper::write_output(&mut dest, readme)

--- a/src/readme/mod.rs
+++ b/src/readme/mod.rs
@@ -1,4 +1,4 @@
-use std::io::Read;
+use std::io::{BufRead, BufReader, Read};
 use std::path::Path;
 
 mod extract;
@@ -18,8 +18,16 @@ pub fn generate_readme<T: Read>(
     add_badges: bool,
     add_license: bool,
     indent_headings: bool,
+    extract_from_comment: bool,
 ) -> Result<String, String> {
-    let lines = extract::extract_docs(source).map_err(|e| format!("{}", e))?;
+    let lines = if extract_from_comment {
+        extract::extract_docs(source).map_err(|e| format!("{}", e))?
+    } else {
+        BufReader::new(source)
+            .lines()
+            .collect::<Result<Vec<_>, _>>()
+            .map_err(|e| format!("{}", e))?
+    };
 
     let readme = process::process_docs(lines, indent_headings).join("\n");
 

--- a/src/readme/mod.rs
+++ b/src/readme/mod.rs
@@ -10,6 +10,7 @@ use crate::config;
 /// Generates readme data from `source` file
 ///
 /// Optionally, a template can be used to render the output
+#[allow(clippy::too_many_arguments)]
 pub fn generate_readme<T: Read>(
     project_root: &Path,
     source: &mut T,

--- a/tests/no-comment-extraction.rs
+++ b/tests/no-comment-extraction.rs
@@ -1,0 +1,62 @@
+use assert_cmd::Command;
+
+// A plain Markdown file (the kind embedded with `#![doc = include_str!(...)]`) is not made of doc
+// comments, so extraction finds nothing and the body comes out empty.
+#[test]
+fn markdown_input_without_flag_is_empty() {
+    let args = [
+        "readme",
+        "--project-root",
+        "tests/test-project",
+        "--no-template",
+        "--no-badges",
+        "--input",
+        "README.rustdoc.md",
+    ];
+
+    Command::cargo_bin(env!("CARGO_PKG_NAME"))
+        .unwrap()
+        .args(args)
+        .assert()
+        .success()
+        .stdout("# readme-test\n\nLicense: MIT\n");
+}
+
+// With `--no-comment-extraction` the same file is processed verbatim: headings are indented, code
+// fences become `rust`, and hidden `# ` lines are dropped, including indented ones.
+#[test]
+fn markdown_input_with_flag_is_processed() {
+    let args = [
+        "readme",
+        "--project-root",
+        "tests/test-project",
+        "--no-template",
+        "--no-badges",
+        "--no-comment-extraction",
+        "--input",
+        "README.rustdoc.md",
+    ];
+
+    let expected = r#"# readme-test
+
+Test crate for cargo-readme
+
+This file is plain Markdown, meant to be embedded with `#![doc = include_str!(...)]`,
+so `cargo readme` must process it verbatim rather than extracting doc comments.
+
+## Examples
+
+```rust
+let visible = "visible";
+```
+
+License: MIT
+"#;
+
+    Command::cargo_bin(env!("CARGO_PKG_NAME"))
+        .unwrap()
+        .args(args)
+        .assert()
+        .success()
+        .stdout(expected);
+}

--- a/tests/test-project/README.rustdoc.md
+++ b/tests/test-project/README.rustdoc.md
@@ -1,0 +1,12 @@
+Test crate for cargo-readme
+
+This file is plain Markdown, meant to be embedded with `#![doc = include_str!(...)]`,
+so `cargo readme` must process it verbatim rather than extracting doc comments.
+
+# Examples
+
+```
+let visible = "visible";
+# let hidden = "hidden";
+    # let hidden_but_indented = "also hidden";
+```


### PR DESCRIPTION
Nowadays, Rustdoc supports to add comment from separate markdown files by

```rust
#![doc = include_str!("README.md")]
```

As a result, it is great to combine this feature with cargo readme to eliminate the annoything `#` lines for GitHub README readers (motivation can be seen [here](https://users.rust-lang.org/t/best-practice-for-doc-testing-readme/114862?u=evian-zhang)).

The ideal workflow is: 

1. User write a readme file `README.rustdoc.md` which is specific for rustdoc, and the `lib.rs` would include such readme file as documentation. 

    In this file, code snippets are meant to be doc tested, and several `#` are added to hide lines. 
2. Then, user would use `cargo readme` to process such file, and generate a `README.md` for the repository. 

    In this README, lines hidden by `#` are removed, and badges, licenses, etc. are added as template do.

However, current `cargo readme` cannot do this, since the file specified in `--input` option would still be treated as a Rust file, and the documentation would be extracted by matching the comment patterns. As a result, I add the `--no-comment-extraction` option, which would treat input file as a plain markdown file, and no more extraction is needed.