### PR TITLE
Fixes some typos and add check in ci

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -14,3 +14,5 @@ jobs:
       - uses: actions/checkout@v3
       - name: CI
         run: make ci
+      - name: Spell Check Repo
+        uses: crate-ci/typos@v1.48.0

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -2,16 +2,15 @@ name: main
 
 on:
   push:
-    branches: [ main ]
+    branches: [main]
   pull_request:
-    branches: [ main ]
+    branches: [main]
 
 jobs:
   build:
-
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v3
-    - name: CI
-      run: make ci
+      - uses: actions/checkout@v3
+      - name: CI
+        run: make ci

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0, 2026-06-18
       - name: CI
         run: make ci
       - name: Spell Check Repo

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -45,7 +45,7 @@ jobs:
 
       # Check out the exact commit requested for release.
       - name: Checkout
-        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0, 2026-06-18
         with:
           # Preserve history for the ancestry and tag checks.
           fetch-depth: 0
@@ -118,7 +118,7 @@ jobs:
     steps:
       # Check out the exact commit that passed verification.
       - name: Checkout
-        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0, 2026-06-18
         with:
           # Preserve history for tagging and release creation.
           fetch-depth: 0

--- a/src/config/badges.rs
+++ b/src/config/badges.rs
@@ -161,14 +161,14 @@ pub fn maintenance(attrs: Attrs) -> String {
 
     // https://github.com/rust-lang/crates.io/blob/5a08887d4b531e034d01386d3e5997514f3c8ee5/src/models/badge.rs#L82
     let status_with_color = match status.as_ref() {
-        "actively-developed" => "activly--developed-brightgreen",
+        "actively-developed" => "actively--developed-brightgreen",
         "passively-maintained" => "passively--maintained-yellowgreen",
         "as-is" => "as--is-yellow",
         "none" => "maintenance-none-lightgrey", // color is a guess
         "experimental" => "experimental-blue",
         "looking-for-maintainer" => "looking--for--maintainer-darkblue", // color is a guess
         "deprecated" => "deprecated-red",
-        _ => "unknow-black",
+        _ => "unknown-black",
     };
 
     //example https://img.shields.io/badge/maintenance-experimental-blue.svg

--- a/src/helper.rs
+++ b/src/helper.rs
@@ -62,7 +62,7 @@ pub fn get_template_file(
                 )
             })
         }
-        // try to read the defautl template file
+        // try to read the default template file
         None => {
             let template = project_root.join(DEFAULT_TEMPLATE);
             match File::open(&template) {


### PR DESCRIPTION
tool [typos](https://github.com/crate-ci/typos/) can be use in command line, in CI (GitHub Action available) and integrated in IDE (Ex: VSCode, Zed)