### PR TITLE
fix: hide indented code starting with '#'

### DIFF
--- a/src/readme/process.rs
+++ b/src/readme/process.rs
@@ -45,7 +45,7 @@ impl Processor {
 
     pub fn process_line(&mut self, mut line: String) -> Option<String> {
         // Skip lines that should be hidden in docs
-        if self.section == Section::CodeRust && line.starts_with("# ") {
+        if self.section == Section::CodeRust && line.trim_ascii_start().starts_with("# ") {
             return None;
         }
 

--- a/tests/test-project/src/lib.rs
+++ b/tests/test-project/src/lib.rs
@@ -9,6 +9,7 @@
 //! # This should NOT be on the output
 //! let condition = true;
 //! if condition {
+//!     # This should also NOT be on the output
 //!     // Some conditional code here
 //!     if condition {
 //!         // Some nested conditional code here


### PR DESCRIPTION
Fixes #129
