### PR TITLE
fix: clippy warnings

### DIFF
--- a/src/config/manifest.rs
+++ b/src/config/manifest.rs
@@ -96,7 +96,7 @@ fn process_badges(badges: BTreeMap<String, BTreeMap<String, String>>) -> Vec<Str
         })
         .collect();
 
-    b.sort_unstable_by(|a, b| a.0.cmp(&b.0));
+    b.sort_unstable_by_key(|a| a.0);
     b.into_iter().map(|(_, badge)| badge).collect()
 }
 


### PR DESCRIPTION
## What

Replaces the closure-based `sort_unstable_by` in `process_badges` with `sort_unstable_by_key`:

```rust
-    b.sort_unstable_by(|a, b| a.0.cmp(&b.0));
+    b.sort_unstable_by_key(|a| a.0);
```

## Why

CI runs `cargo clippy --all-features --tests -- -D warnings` (via `make ci`). On the runner's current stable (clippy **1.96.0**), the `clippy::unnecessary_sort_by` lint fires on this line and, under `-D warnings`, fails the build. Behavior is unchanged — badge keys are unique `u16`s, so sorting by key is equivalent, and this is clippy's own suggested rewrite.

This is pre-existing code (unchanged since 2018), not introduced by any open PR; it surfaced only because the `ubuntu-latest` toolchain advanced to 1.96. Landing it on `main` also unblocks CI for #130, which is currently red for this unrelated reason.

## Verification

Reproduced and validated on a matching toolchain (rustc/clippy 1.96.0):
- **Before:** `clippy … -D warnings` errors at `src/config/manifest.rs:99`.
- **After:** full `make ci` (check, fmt-check, clippy, test, build, install) passes — 42 unit tests + all integration tests green, no further lints.
