### PR TITLE
feat: Cargo workspace inheritance

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -92,10 +92,22 @@ name = "cargo-readme"
 version = "3.3.3"
 dependencies = [
  "assert_cmd",
+ "cargo_toml",
  "clap",
  "percent-encoding",
  "predicates",
  "regex",
+ "serde",
+ "toml",
+]
+
+[[package]]
+name = "cargo_toml"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aa61aec073ec94791433ddf3df2323ff9d1711557c2a0eefb0f99cb4f8dca520"
+dependencies = [
+ "semver",
  "serde",
  "toml",
 ]
@@ -283,6 +295,16 @@ name = "regex-syntax"
 version = "0.8.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6f6ff9a378485b298a5286656da665ba74413d36db0979633275d2e708145d4"
+
+[[package]]
+name = "semver"
+version = "1.0.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd"
+dependencies = [
+ "serde",
+ "serde_core",
+]
 
 [[package]]
 name = "serde"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,7 @@ license = "MIT OR Apache-2.0"
 rust-version = "1.80"
 
 [dependencies]
+cargo_toml = "1"
 clap = { version = "4", features = [ "derive" ] }
 toml = "1"
 regex = "1"

--- a/src/config/manifest.rs
+++ b/src/config/manifest.rs
@@ -2,30 +2,31 @@
 
 use serde::Deserialize;
 use std::collections::BTreeMap;
-use std::fs::File;
-use std::io::Read;
 use std::path::{Path, PathBuf};
 
 use super::badges;
 
 /// Try to get manifest info from Cargo.toml
 pub fn get_manifest(project_root: &Path) -> Result<Manifest, String> {
-    let mut cargo_toml = File::open(project_root.join("Cargo.toml"))
+    let cargo_toml_path = project_root.join("Cargo.toml");
+
+    let manifest = cargo_toml::Manifest::<toml::Value>::from_path(&cargo_toml_path)
         .map_err(|e| format!("Could not read Cargo.toml: {}", e))?;
 
-    let buf = {
-        let mut buf = String::new();
-        cargo_toml
-            .read_to_string(&mut buf)
-            .map_err(|e| format!("{}", e))?;
-        buf
-    };
+    let raw_toml_text = std::fs::read_to_string(&cargo_toml_path)
+        .map_err(|e| format!("Could not read Cargo.toml: {}", e))?;
+    let raw_toml: RawBadges = toml::from_str(&raw_toml_text).map_err(|e| format!("{}", e))?;
 
-    let cargo_toml: CargoToml = toml::from_str(&buf).map_err(|e| format!("{}", e))?;
+    Manifest::try_new(manifest, raw_toml.badges)
+}
 
-    let manifest = Manifest::new(cargo_toml);
-
-    Ok(manifest)
+/// Error message for a field that could not be resolved through workspace inheritance
+fn workspace_inherit_err(field: &str) -> String {
+    format!(
+        "Could not resolve `{field}`: the crate sets `{field}.workspace = true`, but no \
+         workspace root defines `{field}` under `[workspace.package]` (or the workspace \
+         root could not be found)"
+    )
 }
 
 #[derive(Debug)]
@@ -39,23 +40,52 @@ pub struct Manifest {
 }
 
 impl Manifest {
-    fn new(cargo_toml: CargoToml) -> Manifest {
-        Manifest {
-            name: cargo_toml.package.name,
-            license: cargo_toml.package.license,
-            lib: cargo_toml.lib.map(ManifestLib::from_cargo_toml),
-            bin: cargo_toml
-                .bin
-                .map(|bin_vec| {
-                    bin_vec
-                        .into_iter()
-                        .map(ManifestLib::from_cargo_toml)
-                        .collect()
-                })
-                .unwrap_or_default(),
-            badges: cargo_toml.badges.map(process_badges).unwrap_or_default(),
-            version: cargo_toml.package.version,
-        }
+    fn try_new(
+        manifest: cargo_toml::Manifest<toml::Value>,
+        badges_raw: Option<BTreeMap<String, BTreeMap<String, String>>>,
+    ) -> Result<Manifest, String> {
+        let package = manifest
+            .package
+            .as_ref()
+            .ok_or_else(|| "Missing [package] section in Cargo.toml".to_string())?;
+
+        let name = package.name.clone();
+
+        let license = package
+            .license
+            .as_ref()
+            .map(|l| l.get().map(|s| s.to_owned()))
+            .transpose()
+            .map_err(|_| workspace_inherit_err("license"))?;
+
+        let lib = manifest
+            .lib
+            .as_ref()
+            .map(ManifestLib::from_product)
+            .transpose()?;
+
+        let bin = manifest
+            .bin
+            .iter()
+            .map(ManifestLib::from_product)
+            .collect::<Result<Vec<_>, _>>()?;
+
+        let badges = badges_raw.map(process_badges).unwrap_or_default();
+
+        let version = package
+            .version
+            .get()
+            .map_err(|_| workspace_inherit_err("version"))?
+            .to_string();
+
+        Ok(Manifest {
+            name,
+            license,
+            lib,
+            bin,
+            badges,
+            version,
+        })
     }
 }
 
@@ -66,11 +96,16 @@ pub struct ManifestLib {
 }
 
 impl ManifestLib {
-    fn from_cargo_toml(lib: CargoTomlLib) -> Self {
-        ManifestLib {
-            path: PathBuf::from(lib.path),
-            doc: lib.doc.unwrap_or(true),
-        }
+    fn from_product(product: &cargo_toml::Product) -> Result<Self, String> {
+        let path = product
+            .path
+            .as_ref()
+            .ok_or_else(|| "Missing path for product".to_string())?;
+
+        Ok(ManifestLib {
+            path: PathBuf::from(path),
+            doc: product.doc,
+        })
     }
 }
 
@@ -100,26 +135,8 @@ fn process_badges(badges: BTreeMap<String, BTreeMap<String, String>>) -> Vec<Str
     b.into_iter().map(|(_, badge)| badge).collect()
 }
 
-/// Cargo.toml crate information
+/// Raw badges extraction from TOML
 #[derive(Clone, Deserialize)]
-struct CargoToml {
-    pub package: CargoTomlPackage,
-    pub lib: Option<CargoTomlLib>,
-    pub bin: Option<Vec<CargoTomlLib>>,
+struct RawBadges {
     pub badges: Option<BTreeMap<String, BTreeMap<String, String>>>,
-}
-
-/// Cargo.toml crate package information
-#[derive(Clone, Deserialize)]
-struct CargoTomlPackage {
-    pub name: String,
-    pub license: Option<String>,
-    pub version: String,
-}
-
-/// Cargo.toml crate lib information
-#[derive(Clone, Deserialize)]
-struct CargoTomlLib {
-    pub path: String,
-    pub doc: Option<bool>,
 }

--- a/tests/workspace-inheritance.rs
+++ b/tests/workspace-inheritance.rs
@@ -1,0 +1,56 @@
+use assert_cmd::Command;
+
+const EXPECTED_TEMPLATE: &str = r#"[![Workflow Status](https://github.com/cargo-readme/test/workflows/main/badge.svg)](https://github.com/cargo-readme/test/actions?query=workflow%3A%22main%22)
+
+# workspace-member
+
+Current version: 1.2.3
+
+A test project using workspace inheritance.
+
+License: MIT
+"#;
+
+const EXPECTED_NO_TEMPLATE: &str = r#"[![Workflow Status](https://github.com/cargo-readme/test/workflows/main/badge.svg)](https://github.com/cargo-readme/test/actions?query=workflow%3A%22main%22)
+
+# workspace-member
+
+A test project using workspace inheritance.
+
+License: MIT
+"#;
+
+#[test]
+fn workspace_inheritance_with_template() {
+    let args = [
+        "readme",
+        "--project-root",
+        "tests/workspace-inheritance/member",
+        "--template",
+        "README.tpl",
+    ];
+
+    Command::cargo_bin(env!("CARGO_PKG_NAME"))
+        .unwrap()
+        .args(args)
+        .assert()
+        .success()
+        .stdout(EXPECTED_TEMPLATE);
+}
+
+#[test]
+fn workspace_inheritance_without_template() {
+    let args = [
+        "readme",
+        "--project-root",
+        "tests/workspace-inheritance/member",
+        "--no-template",
+    ];
+
+    Command::cargo_bin(env!("CARGO_PKG_NAME"))
+        .unwrap()
+        .args(args)
+        .assert()
+        .success()
+        .stdout(EXPECTED_NO_TEMPLATE);
+}

--- a/tests/workspace-inheritance/Cargo.toml
+++ b/tests/workspace-inheritance/Cargo.toml
@@ -1,0 +1,10 @@
+[workspace]
+members = ["member"]
+
+[workspace.package]
+version = "1.2.3"
+license = "MIT"
+edition = "2021"
+
+[workspace.dependencies]
+serde = "1"

--- a/tests/workspace-inheritance/member/Cargo.toml
+++ b/tests/workspace-inheritance/member/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "workspace-member"
+version.workspace = true
+license.workspace = true
+edition.workspace = true
+
+[badges]
+github = { repository = "cargo-readme/test" }
+
+[dependencies]
+serde = { workspace = true }

--- a/tests/workspace-inheritance/member/README.tpl
+++ b/tests/workspace-inheritance/member/README.tpl
@@ -1,0 +1,9 @@
+{{badges}}
+
+# {{crate}}
+
+Current version: {{version}}
+
+{{readme}}
+
+License: {{license}}

--- a/tests/workspace-inheritance/member/src/lib.rs
+++ b/tests/workspace-inheritance/member/src/lib.rs
@@ -1,0 +1,1 @@
+//! A test project using workspace inheritance.


### PR DESCRIPTION
## Context

This is my first real contribution. I've contacted @webern and proposed to co-maintain the project with the purpose of picking up on the backlog. @webern is still in the loop for review and approval.

## Change

Support crates that inherit fields from `[workspace.package]` (e.g. `version.workspace = true`) by delegating manifest parsing to the `cargo_toml` crate, which resolves inheritance by walking up to the workspace root. A hand-rolled resolver would only cover a fixed set of fields and drift from Cargo's own rules over time.

manifest:
- parse with `cargo_toml::Manifest::from_path`, which resolves inherited fields as it loads
- keep parsing badges from raw TOML: cargo_toml exposes them as a typed struct that drops unknown types
- name the unresolved field and point at `[workspace.package]` in inheritance errors
- propagate malformed `[lib]`/`[[bin]]` errors instead of silently dropping the target

tests:
- add a member crate asserting the inherited version via template, not just the license
- cover both `--template` and `--no-template`, plus badge processing alongside inheritance
- inherit a `[workspace.dependencies]` entry too, so parsing is exercised against inherited deps

## Discussion

Since #98 and #82 had different takes, I went with `cargo_toml` because it is most forward-compatible. The #98 discussion leaned toward dropping badge support, since `cargo_toml` doesn't model `[badges.github]` and the `[badges]` section is deprecated. This PR keeps it non-breaking instead: badges are read from raw TOML separately, so `[badges.github]` and all other types still render (there's a test for it). Judging by the issue tracker, improved badge support is the second-most sought feature, so I'll tackle that separately.

## Book keeping

- Fixes #81
- Closes #98
- Closes #82