### PR TITLE
chore: release v3.3.3

### DIFF
--- a/.agents/skills
+++ b/.agents/skills
@@ -1,0 +1,1 @@
+../.claude/skills

--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -1,1 +1,0 @@
-read AGENTS.md

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,15 @@
+{
+  "hooks": {
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "printf '{\"hookSpecificOutput\":{\"hookEventName\":\"SessionStart\",\"additionalContext\":\"Before doing any work in this session, read AGENTS.md.\"}}'",
+            "statusMessage": "Reading AGENTS.md..."
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/.claude/skills/publish/SKILL.md
+++ b/.claude/skills/publish/SKILL.md
@@ -7,7 +7,6 @@ user-invocable: true
 allowed-tools: Bash Read Grep Glob Edit Write Agent AskUserQuestion TaskCreate TaskUpdate TaskList WebSearch WebFetch LSP NotebookEdit
 effort: high
 ---
-
 # Publish v$0
 
 You are a release assistant. Your job is to walk the user through publishing version `$0` of this
@@ -62,8 +61,8 @@ This is the most important phase. Follow these instructions precisely.
 
 1. Read `CHANGELOG.md` in full.
 2. Derive the repo URL: `gh repo view --json url --jq .url`
-3. Identify the **previous version** from the CHANGELOG — this is the first `## [x.y.z]` entry
-   after `## [Unreleased]`.
+3. Identify the **previous version** from the CHANGELOG — this is the first `## [x.y.z]` entry after
+   `## [Unreleased]`.
 4. Find the date of the previous version's tag:
    ```bash
    git log -1 --format=%ai v{previous_version}
@@ -188,6 +187,13 @@ Once approved, update `CHANGELOG.md`:
    ```
 6. Report CI status to the user. If CI fails, help diagnose and fix.
 
+## Phase 7: Wait for PR Merge
+
+The user will merge the PR on GitHub or authorize you to do so. After that you need to switch to
+main, pull from the correct remote, confirm that you are looking at the same repo state that you
+were previously. Rerun the cargo publish dry-run and tell the user that we are ready for publishing
+and tagging.
+
 ## Phase 7: Publish to crates.io
 
 1. **Ask the user**: "CI is green. Ready to publish v$0 to crates.io?"
@@ -215,8 +221,8 @@ Once approved, update `CHANGELOG.md`:
    gh pr merge release/v$0 --merge
    ```
 3. Extract the CHANGELOG entry for this version (everything between `## [$0]` and the next `## [`)
-   to use as the release body. Include the category headers and items but NOT the PR reference
-   links at the bottom of the section (GitHub will auto-link `#nn` references).
+   to use as the release body. Include the category headers and items but NOT the PR reference links
+   at the bottom of the section (GitHub will auto-link `#nn` references).
 4. **Ask the user** before creating the release.
 5. Create the GitHub release:
    ```bash

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,28 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [3.3.3] - 2026-07-14
+
+### Changed
+
+- Update dependencies, including toml v0.8 to v1, and replace `lazy_lock` with `std::sync::LazyLock` and deprecated `assert_cli` with `assert_cmd`. [#113]
+- Update clap from v4.6.0 to v4.6.1. [#127]
+- Update regex from v1.12.3 to v1.13.0. [#134]
+
+### Added
+
+- Support `compile_fail` code blocks in generated README output. [#116]
+
+### Fixed
+
+- Hide indented lines beginning with `#` in Rust code blocks. [#130]
+
+[#113]: https://github.com/webern/cargo-readme/pull/113
+[#127]: https://github.com/webern/cargo-readme/pull/127
+[#134]: https://github.com/webern/cargo-readme/pull/134
+[#116]: https://github.com/webern/cargo-readme/pull/116
+[#130]: https://github.com/webern/cargo-readme/pull/130
+
 ## [3.3.2] - 2026-04-09
 
 ### Changed
@@ -45,7 +67,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 [#84]: https://github.com/webern/cargo-readme/pull/84
 
-[unreleased]: https://github.com/webern/cargo-readme/compare/v3.3.2...HEAD
+[unreleased]: https://github.com/webern/cargo-readme/compare/v3.3.3...HEAD
+[3.3.3]: https://github.com/webern/cargo-readme/compare/v3.3.2...v3.3.3
 [3.3.2]: https://github.com/webern/cargo-readme/compare/v3.3.1...v3.3.2
 [3.3.1]: https://github.com/webern/cargo-readme/compare/v3.3.0...v3.3.1
 [3.3.0]: https://github.com/webern/cargo-readme/compare/v3.2.0...v3.3.0

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -89,7 +89,7 @@ dependencies = [
 
 [[package]]
 name = "cargo-readme"
-version = "3.3.2"
+version = "3.3.3"
 dependencies = [
  "assert_cmd",
  "clap",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -348,9 +348,9 @@ checksum = "8f50febec83f5ee1df3015341d8bd429f2d1cc62bcba7ea2076759d315084683"
 
 [[package]]
 name = "toml"
-version = "1.1.2+spec-1.1.0"
+version = "1.1.3+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81f3d15e84cbcd896376e6730314d59fb5a87f31e4b038454184435cd57defee"
+checksum = "53c96ecdfa941c8fc4fcaed14f99ada8ebed502eef533015095a07e3301d4c3c"
 dependencies = [
  "indexmap",
  "serde_core",
@@ -381,9 +381,9 @@ dependencies = [
 
 [[package]]
 name = "toml_writer"
-version = "1.1.1+spec-1.1.0"
+version = "1.1.2+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "756daf9b1013ebe47a8776667b466417e2d4c5679d441c26230efd9ef78692db"
+checksum = "7d56353a2a665ad0f41a421187180aab746c8c325620617ad883a99a1cbe66d2"
 
 [[package]]
 name = "unicode-ident"


### PR DESCRIPTION
This release gets dependency updates out as a patch release before we do feature development.

TODO: make releasing fully ci/cd. Possibly delete CHANGELOG.md in the process since that is the only thing that cannot be easily done with github actions afaik.