### PR TITLE
fix(template): warn instead of error on empty badges/license

### DIFF
--- a/src/readme/template.rs
+++ b/src/readme/template.rs
@@ -63,22 +63,19 @@ fn process_template(
 
     if template.contains("{{badges}}") {
         if badges.is_empty() {
-            return Err(
-                "`{{badges}}` was found in template but no badges were provided".to_owned(),
-            );
+            let msg = "`{{badges}}` was found in template but no badges were provided";
+            eprintln!("Warn: {msg}");
         }
         let badges = badges.join("\n");
         template = template.replace("{{badges}}", &badges);
     }
 
     if template.contains("{{license}}") {
-        if let Some(license) = license {
-            template = template.replace("{{license}}", license);
-        } else {
-            return Err(
-                "`{{license}}` was found in template but no license was provided".to_owned(),
-            );
+        if license.is_none() {
+            let msg = "`{{license}}` was found in template but no license was provided";
+            eprintln!("Warn: {msg}");
         }
+        template = template.replace("{{license}}", license.unwrap_or(""));
     }
 
     template = template.replace("{{version}}", version);
@@ -167,37 +164,31 @@ mod tests {
     }
 
     #[test]
-    fn template_with_badge_tag_but_missing_badges_should_fail() {
+    fn template_with_badge_tag_but_missing_badges_should_warn() {
         let result = super::process_template(
             TEMPLATE_WITH_BADGES.to_owned(),
-            String::new(),
+            "readme".to_owned(),
             "",
             &[],
             None,
             "",
         );
-        assert!(result.is_err());
-        assert_eq!(
-            "`{{badges}}` was found in template but no badges were provided",
-            result.unwrap_err()
-        );
+        assert!(result.is_ok());
+        assert_eq!("\n\nreadme", result.unwrap());
     }
 
     #[test]
-    fn template_with_license_tag_but_missing_license_should_fail() {
+    fn template_with_license_tag_but_missing_license_should_warn() {
         let result = super::process_template(
             TEMPLATE_WITH_LICENSE.to_owned(),
-            String::new(),
+            "readme".to_owned(),
             "",
             &[],
             None,
             "",
         );
-        assert!(result.is_err());
-        assert_eq!(
-            "`{{license}}` was found in template but no license was provided",
-            result.unwrap_err()
-        );
+        assert!(result.is_ok());
+        assert_eq!("readme\n\n", result.unwrap());
     }
 
     #[test]

--- a/tests/missing-badges-license.rs
+++ b/tests/missing-badges-license.rs
@@ -1,0 +1,21 @@
+use assert_cmd::Command;
+
+const EXPECTED: &str = "\n\n# missing-badges-license\n\nTest crate for cargo-readme\n\nLicense: \n";
+
+const EXPECTED_WARNINGS: &str =
+    "Warn: `{{badges}}` was found in template but no badges were provided
+Warn: `{{license}}` was found in template but no license was provided
+";
+
+#[test]
+fn missing_badges_license() {
+    let args = ["readme", "--project-root", "tests/missing-badges-license"];
+
+    Command::cargo_bin(env!("CARGO_PKG_NAME"))
+        .unwrap()
+        .args(args)
+        .assert()
+        .success()
+        .stdout(EXPECTED)
+        .stderr(EXPECTED_WARNINGS);
+}

--- a/tests/missing-badges-license/.gitignore
+++ b/tests/missing-badges-license/.gitignore
@@ -1,0 +1,1 @@
+Cargo.lock

--- a/tests/missing-badges-license/Cargo.toml
+++ b/tests/missing-badges-license/Cargo.toml
@@ -1,0 +1,3 @@
+[package]
+name = "missing-badges-license"
+version = "0.1.0"

--- a/tests/missing-badges-license/README.tpl
+++ b/tests/missing-badges-license/README.tpl
@@ -1,0 +1,7 @@
+{{badges}}
+
+# {{crate}}
+
+{{readme}}
+
+License: {{license}}

--- a/tests/missing-badges-license/src/lib.rs
+++ b/tests/missing-badges-license/src/lib.rs
@@ -1,0 +1,1 @@
+//! Test crate for cargo-readme


### PR DESCRIPTION
Why:
- crates.io removed badge display, so a `{{badges}}`/`{{license}}` placeholder resolving to nothing is now a normal case rather than a template error.

What:
- Warn to stderr and substitute an empty string instead of erroring; warn-by-default, no new flag.
- Keep the missing `{{readme}}` placeholder a hard error since the output would be meaningless.

Refs:
- Closes #42
- Supersedes #43