### PR TITLE
Add every rustdoc language annotation (port rustdoc's classifier)

### DIFF
--- a/src/readme/process.rs
+++ b/src/readme/process.rs
@@ -1,7 +1,8 @@
 //! Transform code blocks from rustdoc into markdown
 //!
 //! Rewrite code block start tags, changing rustdoc into equivalent in markdown:
-//! - "```", "```no_run", "```ignore", "```should_panic", and "```compile_fail" are converted to "```rust"
+//! - code blocks that rustdoc treats as rust are converted to "```rust"
+//! - "```text" has its language stripped, becoming a plain "```"
 //! - markdown heading are indentend to be one level lower, so the crate name is at the top level
 
 use regex::Regex;
@@ -10,20 +11,60 @@ use std::{
     sync::LazyLock,
 };
 
-// Is this code block rust?
-static RE_CODE_RUST: LazyLock<Regex> = LazyLock::new(|| {
-    Regex::new(
-        r"^(?P<delimiter>`{3,4}|~{3,4})(?:rust|(?:(?:rust,)?(?:no_run|ignore|should_panic|compile_fail)))?$",
-    )
-    .unwrap()
-});
-// Is this code block just text?
-static RE_CODE_TEXT: LazyLock<Regex> =
-    LazyLock::new(|| Regex::new(r"^(?P<delimiter>`{3,4}|~{3,4})text$").unwrap());
+// A fenced code block opening: 3-4 backticks/tildes and an optional info string.
+static RE_CODE_FENCE: LazyLock<Regex> =
+    LazyLock::new(|| Regex::new(r"^(?P<delimiter>`{3,4}|~{3,4})(?P<info>.*)$").unwrap());
 
-// Is this code block a language other than rust?
-static RE_CODE_OTHER: LazyLock<Regex> =
-    LazyLock::new(|| Regex::new(r"^(?P<delimiter>`{3,4}|~{3,4})\w[\w,\+]*$").unwrap());
+/// Does this code block info string denote rust?
+///
+/// Mirrors rustdoc's `LangString::parse` (an unpublished, `rustc_private`
+/// function we cannot depend on directly), ported from rust-lang/rust@a9cf06b5.
+/// A block is rust unless a `custom` tag appears, or an unrecognized tag appears
+/// without an explicit `rust` tag. To check for drift, diff `LangString::parse`
+/// against this function.
+///
+/// Typo variants like `should-panic` or `norun` are deliberately not rust:
+/// rustdoc treats them as markers for other languages, so we keep them verbatim.
+fn is_rust_code(info: &str) -> bool {
+    let mut seen_rust_tags = false;
+    let mut seen_other_tags = false;
+    let mut seen_custom_tag = false;
+
+    for token in info.split([' ', ',', '\t']).filter(|t| !t.is_empty()) {
+        match token {
+            "should_panic" | "no_run" | "ignore" => {
+                seen_rust_tags = !seen_other_tags;
+            }
+            "rust" => {
+                seen_rust_tags = true;
+            }
+            "custom" => {
+                seen_custom_tag = true;
+            }
+            "test_harness" | "compile_fail" | "standalone_crate" => {
+                seen_rust_tags = !seen_other_tags || seen_rust_tags;
+            }
+            _ if token.starts_with("ignore-") => {
+                seen_rust_tags = !seen_other_tags;
+            }
+            // `edition*` sets the edition only; it is neither a rust nor an other tag.
+            _ if token.starts_with("edition") => {}
+            _ if is_error_code(token) => {
+                seen_rust_tags = !seen_other_tags || seen_rust_tags;
+            }
+            _ => {
+                seen_other_tags = true;
+            }
+        }
+    }
+
+    !seen_custom_tag && (!seen_other_tags || seen_rust_tags)
+}
+
+/// A rustdoc error-code tag: `E` followed by exactly four ASCII digits (e.g. `E0277`).
+fn is_error_code(token: &str) -> bool {
+    matches!(token.strip_prefix('E'), Some(rest) if rest.len() == 4 && rest.bytes().all(|b| b.is_ascii_digit()))
+}
 
 /// Process and concatenate the doc lines into a single String
 ///
@@ -62,17 +103,20 @@ impl Processor {
             line.insert(0, '#');
         } else if self.section == Section::None {
             let l = line.clone();
-            if let Some(cap) = RE_CODE_RUST.captures(&l) {
-                self.section = Section::CodeRust;
-                self.delimiter = cap.name("delimiter").map(|x| x.as_str().to_owned());
-                line = format!("{}rust", self.delimiter.as_ref().unwrap());
-            } else if let Some(cap) = RE_CODE_TEXT.captures(&l) {
-                self.section = Section::CodeOther;
-                self.delimiter = cap.name("delimiter").map(|x| x.as_str().to_owned());
-                line = self.delimiter.clone().unwrap();
-            } else if let Some(cap) = RE_CODE_OTHER.captures(&l) {
-                self.section = Section::CodeOther;
-                self.delimiter = cap.name("delimiter").map(|x| x.as_str().to_owned());
+            if let Some(cap) = RE_CODE_FENCE.captures(&l) {
+                let delimiter = cap.name("delimiter").unwrap().as_str();
+                let info = cap.name("info").unwrap().as_str();
+                self.delimiter = Some(delimiter.to_owned());
+                if is_rust_code(info) {
+                    self.section = Section::CodeRust;
+                    line = format!("{delimiter}rust");
+                } else {
+                    self.section = Section::CodeOther;
+                    // "```text" is stripped to a plain fence; other languages are kept as-is.
+                    if info.trim() == "text" {
+                        line = delimiter.to_owned();
+                    }
+                }
             }
         } else if self.section != Section::None && Some(&line) == self.delimiter.as_ref() {
             self.section = Section::None;
@@ -242,6 +286,113 @@ mod tests {
     fn transform_rust_code_block_with_prefix() {
         let result = process_docs(INPUT_RUST_CODE_BLOCK_RUST_PREFIX, true);
         assert_eq!(result, EXPECTED_RUST_CODE_BLOCK);
+    }
+
+    const INPUT_RUST_CODE_BLOCK_ALL_ANNOTATIONS: &[&str] = &[
+        "```test_harness",
+        "let a = test_harness;",
+        "```",
+        "",
+        "```standalone_crate",
+        "let a = standalone;",
+        "```",
+        "",
+        "```edition2018",
+        "let a = edition;",
+        "```",
+        "",
+        "```E0277",
+        "let a = error_code;",
+        "```",
+        "",
+        "```ignore-windows",
+        "let a = ignore_target;",
+        "```",
+    ];
+
+    const EXPECTED_RUST_CODE_BLOCK_ALL_ANNOTATIONS: &[&str] = &[
+        "```rust",
+        "let a = test_harness;",
+        "```",
+        "",
+        "```rust",
+        "let a = standalone;",
+        "```",
+        "",
+        "```rust",
+        "let a = edition;",
+        "```",
+        "",
+        "```rust",
+        "let a = error_code;",
+        "```",
+        "",
+        "```rust",
+        "let a = ignore_target;",
+        "```",
+    ];
+
+    #[test]
+    fn transform_rust_code_block_all_annotations() {
+        let result = process_docs(INPUT_RUST_CODE_BLOCK_ALL_ANNOTATIONS, true);
+        assert_eq!(result, EXPECTED_RUST_CODE_BLOCK_ALL_ANNOTATIONS);
+    }
+
+    const INPUT_RUST_CODE_BLOCK_MULTIPLE_TAGS: &[&str] = &[
+        "```rust,no_run",
+        "let a = 1;",
+        "```",
+        "",
+        "```no_run,should_panic",
+        "let a = 2;",
+        "```",
+        "",
+        "```rust,edition2021,compile_fail",
+        "let a = 3;",
+        "```",
+    ];
+
+    const EXPECTED_RUST_CODE_BLOCK_MULTIPLE_TAGS: &[&str] = &[
+        "```rust",
+        "let a = 1;",
+        "```",
+        "",
+        "```rust",
+        "let a = 2;",
+        "```",
+        "",
+        "```rust",
+        "let a = 3;",
+        "```",
+    ];
+
+    #[test]
+    fn transform_rust_code_block_multiple_tags() {
+        let result = process_docs(INPUT_RUST_CODE_BLOCK_MULTIPLE_TAGS, true);
+        assert_eq!(result, EXPECTED_RUST_CODE_BLOCK_MULTIPLE_TAGS);
+    }
+
+    // rustdoc treats typo variants (hyphenated / run-together) as markers for
+    // *other* languages, emitting a "did you mean" lint rather than compiling
+    // them as Rust. We faithfully keep them verbatim as non-Rust blocks.
+    const INPUT_TYPO_ANNOTATIONS_NOT_RUST: &[&str] = &[
+        "```should-panic",
+        "let a = 1;",
+        "```",
+        "",
+        "```norun",
+        "let a = 2;",
+        "```",
+        "",
+        "```compile-fail",
+        "let a = 3;",
+        "```",
+    ];
+
+    #[test]
+    fn typo_annotations_are_not_rust() {
+        let result = process_docs(INPUT_TYPO_ANNOTATIONS_NOT_RUST, true);
+        assert_eq!(result, INPUT_TYPO_ANNOTATIONS_NOT_RUST);
     }
 
     const INPUT_TEXT_BLOCK: &[&str] = &["```text", "this is text", "```"];


### PR DESCRIPTION
- This reworks and closes #83

Rather than extend an exhaustive regex of literal annotations, it ports rustdoc's own tokenize-and-classify algorithm so the recognized set stays correct without list maintenance.

## Why port the algorithm?

rustdoc doesn't match a list at all, it runs an algorithm:
- A code block is Rust *by default* and stays Rust unless a `custom` tag appears, or an unrecognized ("other") tag appears without an explicit `rust` tag to override it.
- That collapses to a single line upstream: `data.rust &= !seen_custom_tag && (!seen_other_tags || seen_rust_tags) && !is_error;`.
- Mirroring that logic is far more robust than chasing an ever-growing list of literal strings.

Using rustdoc's classifier directly, isn't feasible:
- `librustdoc` is not published to crates.io
- it lives inside the `rust-lang/rust` tree and is only ever compiled into the `rustdoc` binary
- the relevant `LangString::parse` is module-private (`LangString` itself is only `pub(crate)`), so there is no API surface to call even if it were published.
- its signature and error path lean on `rustc_span::edition::Edition` and the compiler's lint machinery, which are `rustc_private` crates available only on nightly with the `rustc-dev` component installed.

#83 assumes that hyphenated and run-together spellings (`should-panic`, `norun`, `compile-fail`, …) are valid Rust annotations. They are not: rustdoc recognizes only the underscore forms and treats those variants as markers for *other* languages, emitting a "did you mean `should_panic`?" lint. Compiling them as Rust would diverge from rustdoc, so this branch keeps them verbatim as non-Rust blocks.

## Changes

feat(process): port rustdoc's code-block classifier for all annotations

process.rs:
- Replace regexes with one fence regex plus `is_rust_code`, ported from rustdoc
- Recognize the full current tag set: should_panic, no_run, ignore, ignore-*, rust, custom, test_harness, compile_fail, standalone_crate, edition*, and E#### codes
- Support multiple comma/space/tab-separated tags, e.g. rust,edition2021,no_run
- Keep "```` ```text ````" stripping and heading indentation behavior unchanged
- Pin the upstream rev the port was taken from in the doc comment, for drift checks
- standalone_crate (Rust 2024) was missing entirely; edition/E-code matching in the PR was a loose `....` wildcard rather than validated prefixes.

tests:
- Add coverage for the full tag set, multi-tag blocks, and the typo-variant divergence

## Upstream change history

How often does the mirrored function actually change? `git log -L` over `LangString::parse` in `rust-lang/rust` leaves one change per year:

| When | Change to the recognized set |
|---|---|
| 2014 | Birth: `should_panic`/`no_run`/`ignore`/`text`; unmarked fences are Rust |
| 2015 | Removed `should_fail` |
| 2016 | `compile_fail` (nightly), `E####` error codes |
| 2017 | `compile_fail` stabilized; `allow_fail` added |
| 2018–19 | `edition` support → stabilized; `ignore-*` per-target ignores |
| 2022 | Removed `allow_fail` |
| 2023 | New eBNF tokenizer (`TagIterator`); `custom` tag — the big rewrite |
| 2024 | `custom` stabilized; `standalone` → `standalone-crate` → `standalone_crate` |
| 2025 | Per-target-ignore rework/stabilization |

While it would be nice to get automatic updates, I can't think of a clear path to that.