### PR TITLE
feat(badges): fix panics/coveralls, add crates.io badge and --list-badges

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,4 +24,5 @@ assert_cmd = "2.0"
 predicates = { version = "3.1", default-features = false }
 
 [badges]
+crates-io = { crate = "cargo-readme" }
 github = { repository = "webern/cargo-readme" }

--- a/README.md
+++ b/README.md
@@ -145,6 +145,34 @@ License: MY_LICENSE
 By default, `README.tpl` will be used as the template, but you can override it using the
 `--template` to choose a different template or `--no-template` to disable it.
 
+## Badges
+
+`crates.io` no longer renders the `[badges]` section of `Cargo.toml` on the crate page, but it
+does render your `README.md`. `cargo-readme` bridges the two: it turns each entry in `[badges]`
+into a markdown badge prepended to the output (unless you pass `--no-badges`). The supported
+keys and the attributes each one reads are:
+
+| Badge key | Required | Optional |
+|---|---|---|
+| `crates-io` *(extension)* | | `crate` (defaults to the package name) |
+| `appveyor` | `repository` | `branch`, `service` |
+| `circle-ci` | `repository` | `branch`, `service` |
+| `gitlab` | `repository` | `branch` |
+| `travis-ci` | `repository` | `branch` |
+| `github` *(extension)* | `repository` | `workflow` |
+| `codecov` | `repository` | `branch`, `service` |
+| `coveralls` | `repository` | `branch`, `service` |
+| `is-it-maintained-issue-resolution` | `repository` | |
+| `is-it-maintained-open-issues` | `repository` | |
+| `maintenance` | `status` | |
+
+`maintenance` is the only badge the [Cargo manifest reference][manifest] still documents; its
+`status` accepts `actively-developed`, `passively-maintained`, `as-is`, `experimental`,
+`looking-for-maintainer`, `deprecated`, and `none`. `github` and `crates-io` are `cargo-readme`
+extensions. Run `cargo readme --list-badges` to print this list from your terminal.
+
+[manifest]: https://doc.rust-lang.org/cargo/reference/manifest.html#the-badges-section
+
 ## Reusing a Markdown file as documentation
 
 Rustdoc can pull a crate's documentation straight from a Markdown file:

--- a/README.tpl
+++ b/README.tpl
@@ -1,4 +1,3 @@
-[![Crates.io](https://img.shields.io/crates/v/cargo-readme.svg)](https://crates.io/crates/cargo-readme)
 {{badges}}
 
 # {{crate}}

--- a/src/config/badges.rs
+++ b/src/config/badges.rs
@@ -10,8 +10,8 @@ const BADGE_WORKFLOW_DEFAULT: &str = "main";
 
 type Attrs = BTreeMap<String, String>;
 
-pub fn appveyor(attrs: Attrs) -> String {
-    let repo = &attrs["repository"];
+pub fn appveyor(attrs: Attrs) -> Result<String, String> {
+    let repo = required(&attrs, "appveyor", "repository")?;
     let branch = attrs
         .get("branch")
         .map(|i| i.as_ref())
@@ -21,15 +21,15 @@ pub fn appveyor(attrs: Attrs) -> String {
         .map(|i| i.as_ref())
         .unwrap_or(BADGE_SERVICE_DEFAULT);
 
-    format!(
+    Ok(format!(
         "[![Build Status](https://ci.appveyor.com/api/projects/status/{service}/{repo}?branch={branch}&svg=true)]\
         (https://ci.appveyor.com/project/{repo}/branch/{branch})",
         repo=repo, branch=branch, service=service
-    )
+    ))
 }
 
-pub fn circle_ci(attrs: Attrs) -> String {
-    let repo = &attrs["repository"];
+pub fn circle_ci(attrs: Attrs) -> Result<String, String> {
+    let repo = required(&attrs, "circle-ci", "repository")?;
     let branch = attrs
         .get("branch")
         .map(|i| i.as_ref())
@@ -41,63 +41,63 @@ pub fn circle_ci(attrs: Attrs) -> String {
             .unwrap_or(BADGE_SERVICE_DEFAULT),
     );
 
-    format!(
+    Ok(format!(
         "[![Build Status](https://circleci.com/{service}/{repo}/tree/{branch}.svg?style=shield)]\
          (https://circleci.com/{service}/{repo}/tree/{branch})",
         repo = repo,
         service = service,
         branch = percent_encode(branch)
-    )
+    ))
 }
 
-pub fn gitlab(attrs: Attrs) -> String {
-    let repo = &attrs["repository"];
+pub fn gitlab(attrs: Attrs) -> Result<String, String> {
+    let repo = required(&attrs, "gitlab", "repository")?;
     let branch = attrs
         .get("branch")
         .map(|i| i.as_ref())
         .unwrap_or(BADGE_BRANCH_DEFAULT);
 
-    format!(
+    Ok(format!(
         "[![Build Status](https://gitlab.com/{repo}/badges/{branch}/pipeline.svg)]\
          (https://gitlab.com/{repo}/commits/master)",
         repo = repo,
         branch = percent_encode(branch)
-    )
+    ))
 }
 
-pub fn travis_ci(attrs: Attrs) -> String {
-    let repo = &attrs["repository"];
+pub fn travis_ci(attrs: Attrs) -> Result<String, String> {
+    let repo = required(&attrs, "travis-ci", "repository")?;
     let branch = attrs
         .get("branch")
         .map(|i| i.as_ref())
         .unwrap_or(BADGE_BRANCH_DEFAULT);
 
-    format!(
+    Ok(format!(
         "[![Build Status](https://travis-ci.org/{repo}.svg?branch={branch})]\
          (https://travis-ci.org/{repo})",
         repo = repo,
         branch = percent_encode(branch)
-    )
+    ))
 }
 
-pub fn github(attrs: Attrs) -> String {
-    let repo = &attrs["repository"];
+pub fn github(attrs: Attrs) -> Result<String, String> {
+    let repo = required(&attrs, "github", "repository")?;
     let workflow = attrs
         .get("workflow")
         .map(|i| i.as_ref())
         .unwrap_or(BADGE_WORKFLOW_DEFAULT);
 
-    format!(
+    Ok(format!(
         "[![Workflow Status](https://github.com/{repo}/workflows/{workflow}/badge.svg)]\
          (https://github.com/{repo}/actions?query=workflow%3A%22{workflow_plus}%22)",
         repo = repo,
         workflow = percent_encode(workflow),
         workflow_plus = percent_encode(&str::replace(workflow, " ", "+"))
-    )
+    ))
 }
 
-pub fn codecov(attrs: Attrs) -> String {
-    let repo = &attrs["repository"];
+pub fn codecov(attrs: Attrs) -> Result<String, String> {
+    let repo = required(&attrs, "codecov", "repository")?;
     let branch = attrs
         .get("branch")
         .map(|i| i.as_ref())
@@ -109,17 +109,17 @@ pub fn codecov(attrs: Attrs) -> String {
             .unwrap_or(BADGE_SERVICE_DEFAULT),
     );
 
-    format!(
+    Ok(format!(
         "[![Coverage Status](https://codecov.io/{service}/{repo}/branch/{branch}/graph/badge.svg)]\
          (https://codecov.io/{service}/{repo})",
         repo = repo,
         branch = percent_encode(branch),
         service = service
-    )
+    ))
 }
 
-pub fn coveralls(attrs: Attrs) -> String {
-    let repo = &attrs["repository"];
+pub fn coveralls(attrs: Attrs) -> Result<String, String> {
+    let repo = required(&attrs, "coveralls", "repository")?;
     let branch = attrs
         .get("branch")
         .map(|i| i.as_ref())
@@ -129,38 +129,38 @@ pub fn coveralls(attrs: Attrs) -> String {
         .map(|i| i.as_ref())
         .unwrap_or(BADGE_SERVICE_DEFAULT);
 
-    format!(
+    Ok(format!(
         "[![Coverage Status](https://coveralls.io/repos/{service}/{repo}/badge.svg?branch=branch)]\
          (https://coveralls.io/{service}/{repo}?branch={branch})",
         repo = repo,
         branch = percent_encode(branch),
         service = service
-    )
+    ))
 }
 
-pub fn is_it_maintained_issue_resolution(attrs: Attrs) -> String {
-    let repo = &attrs["repository"];
-    format!(
+pub fn is_it_maintained_issue_resolution(attrs: Attrs) -> Result<String, String> {
+    let repo = required(&attrs, "is-it-maintained-issue-resolution", "repository")?;
+    Ok(format!(
         "[![Average time to resolve an issue](https://isitmaintained.com/badge/resolution/{repo}.svg)]\
         (https://isitmaintained.com/project/{repo} \"Average time to resolve an issue\")",
         repo=repo
-    )
+    ))
 }
 
-pub fn is_it_maintained_open_issues(attrs: Attrs) -> String {
-    let repo = &attrs["repository"];
-    format!(
+pub fn is_it_maintained_open_issues(attrs: Attrs) -> Result<String, String> {
+    let repo = required(&attrs, "is-it-maintained-open-issues", "repository")?;
+    Ok(format!(
         "[![Percentage of issues still open](https://isitmaintained.com/badge/open/{repo}.svg)]\
          (https://isitmaintained.com/project/{repo} \"Percentage of issues still open\")",
         repo = repo
-    )
+    ))
 }
 
-pub fn maintenance(attrs: Attrs) -> String {
-    let status = &attrs["status"];
+pub fn maintenance(attrs: Attrs) -> Result<String, String> {
+    let status = required(&attrs, "maintenance", "status")?;
 
     // https://github.com/rust-lang/crates.io/blob/5a08887d4b531e034d01386d3e5997514f3c8ee5/src/models/badge.rs#L82
-    let status_with_color = match status.as_ref() {
+    let status_with_color = match status {
         "actively-developed" => "actively--developed-brightgreen",
         "passively-maintained" => "passively--maintained-yellowgreen",
         "as-is" => "as--is-yellow",
@@ -172,10 +172,18 @@ pub fn maintenance(attrs: Attrs) -> String {
     };
 
     //example https://img.shields.io/badge/maintenance-experimental-blue.svg
-    format!(
+    Ok(format!(
         "![Maintenance](https://img.shields.io/badge/maintenance-{status}.svg)",
         status = status_with_color
-    )
+    ))
+}
+
+/// Look up an attribute that a badge cannot render without.
+fn required<'a>(attrs: &'a Attrs, badge: &str, key: &str) -> Result<&'a str, String> {
+    attrs
+        .get(key)
+        .map(String::as_str)
+        .ok_or_else(|| format!("badge `{badge}` is missing required attribute `{key}`"))
 }
 
 fn percent_encode(input: &str) -> pe::PercentEncode<'_> {

--- a/src/config/badges.rs
+++ b/src/config/badges.rs
@@ -178,6 +178,16 @@ pub fn maintenance(attrs: Attrs) -> Result<String, String> {
     ))
 }
 
+pub fn crates_io(attrs: Attrs, crate_name: &str) -> Result<String, String> {
+    // Not part of the official `[badges]` set, but the crate name is already in
+    // `Cargo.toml`, so `crate` defaults to the package name when omitted.
+    let name = attrs.get("crate").map(|s| s.as_ref()).unwrap_or(crate_name);
+    Ok(format!(
+        "[![Crates.io](https://img.shields.io/crates/v/{name}.svg)](https://crates.io/crates/{name})",
+        name = name
+    ))
+}
+
 /// Look up an attribute that a badge cannot render without.
 fn required<'a>(attrs: &'a Attrs, badge: &str, key: &str) -> Result<&'a str, String> {
     attrs

--- a/src/config/badges.rs
+++ b/src/config/badges.rs
@@ -10,6 +10,92 @@ const BADGE_WORKFLOW_DEFAULT: &str = "main";
 
 type Attrs = BTreeMap<String, String>;
 
+/// A badge key cargo-readme understands, plus which attributes it reads.
+///
+/// This is the single source of truth behind `cargo readme --list-badges`. The
+/// `key`s here must stay in sync with the match arms in [`super::manifest::process_badges`];
+/// a unit test in that module enforces it.
+pub struct BadgeInfo {
+    /// The `[badges]` table key, e.g. `"coveralls"`.
+    pub key: &'static str,
+    /// Whether crates.io documents this badge in the manifest reference.
+    pub official: bool,
+    /// Attributes that must be present, or badge rendering fails.
+    pub required: &'static [&'static str],
+    /// Attributes that are read when present, otherwise defaulted.
+    pub optional: &'static [&'static str],
+}
+
+/// Every badge cargo-readme can render, in the order they appear in the output.
+pub const SUPPORTED_BADGES: &[BadgeInfo] = &[
+    BadgeInfo {
+        key: "crates-io",
+        official: false,
+        required: &[],
+        optional: &["crate"],
+    },
+    BadgeInfo {
+        key: "appveyor",
+        official: true,
+        required: &["repository"],
+        optional: &["branch", "service"],
+    },
+    BadgeInfo {
+        key: "circle-ci",
+        official: true,
+        required: &["repository"],
+        optional: &["branch", "service"],
+    },
+    BadgeInfo {
+        key: "gitlab",
+        official: true,
+        required: &["repository"],
+        optional: &["branch"],
+    },
+    BadgeInfo {
+        key: "travis-ci",
+        official: true,
+        required: &["repository"],
+        optional: &["branch"],
+    },
+    BadgeInfo {
+        key: "github",
+        official: false,
+        required: &["repository"],
+        optional: &["workflow"],
+    },
+    BadgeInfo {
+        key: "codecov",
+        official: true,
+        required: &["repository"],
+        optional: &["branch", "service"],
+    },
+    BadgeInfo {
+        key: "coveralls",
+        official: true,
+        required: &["repository"],
+        optional: &["branch", "service"],
+    },
+    BadgeInfo {
+        key: "is-it-maintained-issue-resolution",
+        official: true,
+        required: &["repository"],
+        optional: &[],
+    },
+    BadgeInfo {
+        key: "is-it-maintained-open-issues",
+        official: true,
+        required: &["repository"],
+        optional: &[],
+    },
+    BadgeInfo {
+        key: "maintenance",
+        official: true,
+        required: &["status"],
+        optional: &[],
+    },
+];
+
 pub fn appveyor(attrs: Attrs) -> Result<String, String> {
     let repo = required(&attrs, "appveyor", "repository")?;
     let branch = attrs

--- a/src/config/badges.rs
+++ b/src/config/badges.rs
@@ -130,7 +130,7 @@ pub fn coveralls(attrs: Attrs) -> Result<String, String> {
         .unwrap_or(BADGE_SERVICE_DEFAULT);
 
     Ok(format!(
-        "[![Coverage Status](https://coveralls.io/repos/{service}/{repo}/badge.svg?branch=branch)]\
+        "[![Coverage Status](https://coveralls.io/repos/{service}/{repo}/badge.svg?branch={branch})]\
          (https://coveralls.io/{service}/{repo}?branch={branch})",
         repo = repo,
         branch = percent_encode(branch),

--- a/src/config/manifest.rs
+++ b/src/config/manifest.rs
@@ -70,7 +70,7 @@ impl Manifest {
             .map(ManifestLib::from_product)
             .collect::<Result<Vec<_>, _>>()?;
 
-        let badges = badges_raw.map(process_badges).unwrap_or_default();
+        let badges = badges_raw.map(process_badges).transpose()?.unwrap_or_default();
 
         let version = package
             .version
@@ -109,8 +109,8 @@ impl ManifestLib {
     }
 }
 
-fn process_badges(badges: BTreeMap<String, BTreeMap<String, String>>) -> Vec<String> {
-    let mut b: Vec<(u16, _)> = badges
+fn process_badges(badges: BTreeMap<String, BTreeMap<String, String>>) -> Result<Vec<String>, String> {
+    let mut b: Vec<(u16, String)> = badges
         .into_iter()
         .filter_map(|(name, attrs)| match name.as_ref() {
             "appveyor" => Some((0, badges::appveyor(attrs))),
@@ -129,10 +129,11 @@ fn process_badges(badges: BTreeMap<String, BTreeMap<String, String>>) -> Vec<Str
             "maintenance" => Some((9, badges::maintenance(attrs))),
             _ => None,
         })
-        .collect();
+        .map(|(order, badge)| badge.map(|b| (order, b)))
+        .collect::<Result<_, _>>()?;
 
     b.sort_unstable_by_key(|a| a.0);
-    b.into_iter().map(|(_, badge)| badge).collect()
+    Ok(b.into_iter().map(|(_, badge)| badge).collect())
 }
 
 /// Raw badges extraction from TOML

--- a/src/config/manifest.rs
+++ b/src/config/manifest.rs
@@ -112,6 +112,8 @@ impl ManifestLib {
     }
 }
 
+// The keys matched here are the source of truth for which badges exist; they must stay
+// in sync with `badges::SUPPORTED_BADGES` (asserted by `supported_badges_in_sync`).
 fn process_badges(
     badges: BTreeMap<String, BTreeMap<String, String>>,
     crate_name: &str,
@@ -147,4 +149,48 @@ fn process_badges(
 #[derive(Clone, Deserialize)]
 struct RawBadges {
     pub badges: Option<BTreeMap<String, BTreeMap<String, String>>>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // Guards against `SUPPORTED_BADGES` (used by --list-badges) drifting from the badge
+    // keys `process_badges` actually renders.
+    #[test]
+    fn supported_badges_in_sync() {
+        let documented: Vec<&str> = badges::SUPPORTED_BADGES.iter().map(|b| b.key).collect();
+        for key in [
+            "crates-io",
+            "appveyor",
+            "circle-ci",
+            "gitlab",
+            "travis-ci",
+            "github",
+            "codecov",
+            "coveralls",
+            "is-it-maintained-issue-resolution",
+            "is-it-maintained-open-issues",
+            "maintenance",
+        ] {
+            let mut attrs = BTreeMap::new();
+            attrs.insert("repository".to_string(), "owner/repo".to_string());
+            attrs.insert("status".to_string(), "actively-developed".to_string());
+            let mut input = BTreeMap::new();
+            input.insert(key.to_string(), attrs);
+
+            let rendered = process_badges(input, "some-crate").unwrap();
+            assert_eq!(rendered.len(), 1, "`{key}` should render a badge");
+            assert!(
+                documented.contains(&key),
+                "`{key}` missing from SUPPORTED_BADGES"
+            );
+        }
+
+        assert_eq!(
+            documented.len(),
+            11,
+            "SUPPORTED_BADGES has an unexpected count"
+        );
+    }
 }

--- a/src/config/manifest.rs
+++ b/src/config/manifest.rs
@@ -70,7 +70,10 @@ impl Manifest {
             .map(ManifestLib::from_product)
             .collect::<Result<Vec<_>, _>>()?;
 
-        let badges = badges_raw.map(process_badges).transpose()?.unwrap_or_default();
+        let badges = badges_raw
+            .map(|b| process_badges(b, &name))
+            .transpose()?
+            .unwrap_or_default();
 
         let version = package
             .version
@@ -109,24 +112,28 @@ impl ManifestLib {
     }
 }
 
-fn process_badges(badges: BTreeMap<String, BTreeMap<String, String>>) -> Result<Vec<String>, String> {
+fn process_badges(
+    badges: BTreeMap<String, BTreeMap<String, String>>,
+    crate_name: &str,
+) -> Result<Vec<String>, String> {
     let mut b: Vec<(u16, String)> = badges
         .into_iter()
         .filter_map(|(name, attrs)| match name.as_ref() {
-            "appveyor" => Some((0, badges::appveyor(attrs))),
-            "circle-ci" => Some((1, badges::circle_ci(attrs))),
-            "gitlab" => Some((2, badges::gitlab(attrs))),
-            "travis-ci" => Some((3, badges::travis_ci(attrs))),
-            "github" => Some((4, badges::github(attrs))),
-            "codecov" => Some((5, badges::codecov(attrs))),
-            "coveralls" => Some((6, badges::coveralls(attrs))),
+            "crates-io" => Some((0, badges::crates_io(attrs, crate_name))),
+            "appveyor" => Some((1, badges::appveyor(attrs))),
+            "circle-ci" => Some((2, badges::circle_ci(attrs))),
+            "gitlab" => Some((3, badges::gitlab(attrs))),
+            "travis-ci" => Some((4, badges::travis_ci(attrs))),
+            "github" => Some((5, badges::github(attrs))),
+            "codecov" => Some((6, badges::codecov(attrs))),
+            "coveralls" => Some((7, badges::coveralls(attrs))),
             "is-it-maintained-issue-resolution" => {
-                Some((7, badges::is_it_maintained_issue_resolution(attrs)))
+                Some((8, badges::is_it_maintained_issue_resolution(attrs)))
             }
             "is-it-maintained-open-issues" => {
-                Some((8, badges::is_it_maintained_open_issues(attrs)))
+                Some((9, badges::is_it_maintained_open_issues(attrs)))
             }
-            "maintenance" => Some((9, badges::maintenance(attrs))),
+            "maintenance" => Some((10, badges::maintenance(attrs))),
             _ => None,
         })
         .map(|(order, badge)| badge.map(|b| (order, b)))

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -2,5 +2,11 @@ mod badges;
 mod manifest;
 pub mod project;
 
+pub use self::badges::{BadgeInfo, SUPPORTED_BADGES};
 pub use self::manifest::get_manifest;
 pub use self::manifest::Manifest;
+
+/// The badges cargo-readme can render, in output order.
+pub fn supported_badges() -> &'static [BadgeInfo] {
+    SUPPORTED_BADGES
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -142,6 +142,34 @@
 //! By default, `README.tpl` will be used as the template, but you can override it using the
 //! `--template` to choose a different template or `--no-template` to disable it.
 //!
+//! # Badges
+//!
+//! `crates.io` no longer renders the `[badges]` section of `Cargo.toml` on the crate page, but it
+//! does render your `README.md`. `cargo-readme` bridges the two: it turns each entry in `[badges]`
+//! into a markdown badge prepended to the output (unless you pass `--no-badges`). The supported
+//! keys and the attributes each one reads are:
+//!
+//! | Badge key | Required | Optional |
+//! |---|---|---|
+//! | `crates-io` *(extension)* | | `crate` (defaults to the package name) |
+//! | `appveyor` | `repository` | `branch`, `service` |
+//! | `circle-ci` | `repository` | `branch`, `service` |
+//! | `gitlab` | `repository` | `branch` |
+//! | `travis-ci` | `repository` | `branch` |
+//! | `github` *(extension)* | `repository` | `workflow` |
+//! | `codecov` | `repository` | `branch`, `service` |
+//! | `coveralls` | `repository` | `branch`, `service` |
+//! | `is-it-maintained-issue-resolution` | `repository` | |
+//! | `is-it-maintained-open-issues` | `repository` | |
+//! | `maintenance` | `status` | |
+//!
+//! `maintenance` is the only badge the [Cargo manifest reference][manifest] still documents; its
+//! `status` accepts `actively-developed`, `passively-maintained`, `as-is`, `experimental`,
+//! `looking-for-maintainer`, `deprecated`, and `none`. `github` and `crates-io` are `cargo-readme`
+//! extensions. Run `cargo readme --list-badges` to print this list from your terminal.
+//!
+//! [manifest]: https://doc.rust-lang.org/cargo/reference/manifest.html#the-badges-section
+//!
 //! # Reusing a Markdown file as documentation
 //!
 //! Rustdoc can pull a crate's documentation straight from a Markdown file:
@@ -160,4 +188,5 @@ mod readme;
 
 pub use config::get_manifest;
 pub use config::project;
+pub use config::{supported_badges, BadgeInfo};
 pub use readme::generate_readme;

--- a/src/main.rs
+++ b/src/main.rs
@@ -70,6 +70,11 @@ struct ReadmeArgs {
     #[clap(long)]
     no_comment_extraction: bool,
 
+    /// List the badges that can be rendered from the `[badges]` section of `Cargo.toml`,
+    /// along with the attributes each one reads, then exit.
+    #[clap(long)]
+    list_badges: bool,
+
     /// File to read from.
     /// If not provided, will try to use `src/lib.rs`, then `src/main.rs`. If neither file
     /// could be found, will look into `Cargo.toml` for a `[lib]`, then for a single `[[bin]]`.
@@ -94,6 +99,10 @@ struct ReadmeArgs {
 
 // Takes the arguments matches from clap and outputs the result, either to stdout of a file
 fn execute(args: &ReadmeArgs) -> Result<(), String> {
+    if args.list_badges {
+        return list_badges();
+    }
+
     // get project root
     let project_root = helper::get_project_root(args.root.as_deref())?;
 
@@ -129,4 +138,26 @@ fn execute(args: &ReadmeArgs) -> Result<(), String> {
     )?;
 
     helper::write_output(&mut dest, readme)
+}
+
+// Print the supported badges and the attributes each one reads. Format mirrors the
+// `[badges]` table so the output can be copied into a Cargo.toml.
+fn list_badges() -> Result<(), String> {
+    let mut out = String::from("Supported badges (add under [badges] in Cargo.toml):\n\n");
+    for badge in cargo_readme::supported_badges() {
+        out.push_str("  ");
+        out.push_str(badge.key);
+        if !badge.official {
+            out.push_str("  (cargo-readme extension)");
+        }
+        out.push('\n');
+        if !badge.required.is_empty() {
+            out.push_str(&format!("    required: {}\n", badge.required.join(", ")));
+        }
+        if !badge.optional.is_empty() {
+            out.push_str(&format!("    optional: {}\n", badge.optional.join(", ")));
+        }
+    }
+    print!("{}", out);
+    Ok(())
 }

--- a/tests/badges-missing-attr.rs
+++ b/tests/badges-missing-attr.rs
@@ -1,0 +1,15 @@
+use assert_cmd::Command;
+
+const EXPECTED: &str = "Error: badge `coveralls` is missing required attribute `repository`\n";
+
+#[test]
+fn badges_missing_attr_fail() {
+    let args = ["readme", "--project-root", "tests/badges-missing-attr"];
+
+    Command::cargo_bin(env!("CARGO_PKG_NAME"))
+        .unwrap()
+        .args(args)
+        .assert()
+        .failure()
+        .stderr(EXPECTED);
+}

--- a/tests/badges-missing-attr/Cargo.toml
+++ b/tests/badges-missing-attr/Cargo.toml
@@ -1,0 +1,8 @@
+[package]
+name = "readme-test"
+version = "0.1.0"
+authors = ["Livio Ribeiro <livioribeiro@outlook.com>"]
+license = "MIT"
+
+[badges]
+coveralls = { branch = "main" }

--- a/tests/badges-missing-attr/src/lib.rs
+++ b/tests/badges-missing-attr/src/lib.rs
@@ -1,0 +1,1 @@
+//! Test crate for cargo-readme

--- a/tests/badges.rs
+++ b/tests/badges.rs
@@ -5,7 +5,7 @@ const EXPECTED: &str = r#"[![Build Status](https://ci.appveyor.com/api/projects/
 [![Build Status](https://gitlab.com/cargo-readme/test/badges/master/pipeline.svg)](https://gitlab.com/cargo-readme/test/commits/master)
 [![Build Status](https://travis-ci.org/cargo-readme/test.svg?branch=master)](https://travis-ci.org/cargo-readme/test)
 [![Coverage Status](https://codecov.io/gh/cargo-readme/test/branch/master/graph/badge.svg)](https://codecov.io/gh/cargo-readme/test)
-[![Coverage Status](https://coveralls.io/repos/github/cargo-readme/test/badge.svg?branch=branch)](https://coveralls.io/github/cargo-readme/test?branch=master)
+[![Coverage Status](https://coveralls.io/repos/github/cargo-readme/test/badge.svg?branch=main)](https://coveralls.io/github/cargo-readme/test?branch=main)
 [![Average time to resolve an issue](https://isitmaintained.com/badge/resolution/cargo-readme/test.svg)](https://isitmaintained.com/project/cargo-readme/test "Average time to resolve an issue")
 [![Percentage of issues still open](https://isitmaintained.com/badge/open/cargo-readme/test.svg)](https://isitmaintained.com/project/cargo-readme/test "Percentage of issues still open")
 

--- a/tests/badges.rs
+++ b/tests/badges.rs
@@ -5,10 +5,12 @@ const EXPECTED: &str = r#"[![Crates.io](https://img.shields.io/crates/v/readme-t
 [![Build Status](https://circleci.com/gh/cargo-readme/test/tree/master.svg?style=shield)](https://circleci.com/gh/cargo-readme/test/tree/master)
 [![Build Status](https://gitlab.com/cargo-readme/test/badges/master/pipeline.svg)](https://gitlab.com/cargo-readme/test/commits/master)
 [![Build Status](https://travis-ci.org/cargo-readme/test.svg?branch=master)](https://travis-ci.org/cargo-readme/test)
+[![Workflow Status](https://github.com/cargo-readme/test/workflows/main/badge.svg)](https://github.com/cargo-readme/test/actions?query=workflow%3A%22main%22)
 [![Coverage Status](https://codecov.io/gh/cargo-readme/test/branch/master/graph/badge.svg)](https://codecov.io/gh/cargo-readme/test)
 [![Coverage Status](https://coveralls.io/repos/github/cargo-readme/test/badge.svg?branch=main)](https://coveralls.io/github/cargo-readme/test?branch=main)
 [![Average time to resolve an issue](https://isitmaintained.com/badge/resolution/cargo-readme/test.svg)](https://isitmaintained.com/project/cargo-readme/test "Average time to resolve an issue")
 [![Percentage of issues still open](https://isitmaintained.com/badge/open/cargo-readme/test.svg)](https://isitmaintained.com/project/cargo-readme/test "Percentage of issues still open")
+![Maintenance](https://img.shields.io/badge/maintenance-actively--developed-brightgreen.svg)
 
 # readme-test
 
@@ -27,4 +29,47 @@ fn badges() {
         .assert()
         .success()
         .stdout(EXPECTED);
+}
+
+const EXPECTED_LIST: &str = r#"Supported badges (add under [badges] in Cargo.toml):
+
+  crates-io  (cargo-readme extension)
+    optional: crate
+  appveyor
+    required: repository
+    optional: branch, service
+  circle-ci
+    required: repository
+    optional: branch, service
+  gitlab
+    required: repository
+    optional: branch
+  travis-ci
+    required: repository
+    optional: branch
+  github  (cargo-readme extension)
+    required: repository
+    optional: workflow
+  codecov
+    required: repository
+    optional: branch, service
+  coveralls
+    required: repository
+    optional: branch, service
+  is-it-maintained-issue-resolution
+    required: repository
+  is-it-maintained-open-issues
+    required: repository
+  maintenance
+    required: status
+"#;
+
+#[test]
+fn list_badges() {
+    Command::cargo_bin(env!("CARGO_PKG_NAME"))
+        .unwrap()
+        .args(["readme", "--list-badges"])
+        .assert()
+        .success()
+        .stdout(EXPECTED_LIST);
 }

--- a/tests/badges.rs
+++ b/tests/badges.rs
@@ -1,6 +1,7 @@
 use assert_cmd::Command;
 
-const EXPECTED: &str = r#"[![Build Status](https://ci.appveyor.com/api/projects/status/github/cargo-readme/test?branch=master&svg=true)](https://ci.appveyor.com/project/cargo-readme/test/branch/master)
+const EXPECTED: &str = r#"[![Crates.io](https://img.shields.io/crates/v/readme-test.svg)](https://crates.io/crates/readme-test)
+[![Build Status](https://ci.appveyor.com/api/projects/status/github/cargo-readme/test?branch=master&svg=true)](https://ci.appveyor.com/project/cargo-readme/test/branch/master)
 [![Build Status](https://circleci.com/gh/cargo-readme/test/tree/master.svg?style=shield)](https://circleci.com/gh/cargo-readme/test/tree/master)
 [![Build Status](https://gitlab.com/cargo-readme/test/badges/master/pipeline.svg)](https://gitlab.com/cargo-readme/test/commits/master)
 [![Build Status](https://travis-ci.org/cargo-readme/test.svg?branch=master)](https://travis-ci.org/cargo-readme/test)

--- a/tests/badges/Cargo.toml
+++ b/tests/badges/Cargo.toml
@@ -10,7 +10,9 @@ appveyor = { repository = "cargo-readme/test" }
 circle-ci = { repository = "cargo-readme/test" }
 gitlab = { repository = "cargo-readme/test" }
 travis-ci = { repository = "cargo-readme/test" }
+github = { repository = "cargo-readme/test" }
 codecov = { repository = "cargo-readme/test" }
 coveralls = { repository = "cargo-readme/test", branch = "main" }
 is-it-maintained-issue-resolution = { repository = "cargo-readme/test" }
 is-it-maintained-open-issues = { repository = "cargo-readme/test" }
+maintenance = { status = "actively-developed" }

--- a/tests/badges/Cargo.toml
+++ b/tests/badges/Cargo.toml
@@ -10,6 +10,6 @@ circle-ci = { repository = "cargo-readme/test" }
 gitlab = { repository = "cargo-readme/test" }
 travis-ci = { repository = "cargo-readme/test" }
 codecov = { repository = "cargo-readme/test" }
-coveralls = { repository = "cargo-readme/test" }
+coveralls = { repository = "cargo-readme/test", branch = "main" }
 is-it-maintained-issue-resolution = { repository = "cargo-readme/test" }
 is-it-maintained-open-issues = { repository = "cargo-readme/test" }

--- a/tests/badges/Cargo.toml
+++ b/tests/badges/Cargo.toml
@@ -5,6 +5,7 @@ authors = ["Livio Ribeiro <livioribeiro@outlook.com>"]
 license = "MIT"
 
 [badges]
+crates-io = {}
 appveyor = { repository = "cargo-readme/test" }
 circle-ci = { repository = "cargo-readme/test" }
 gitlab = { repository = "cargo-readme/test" }


### PR DESCRIPTION
I looked over the remaining issues and PRs and saw a common theme being improved badge support.

- Closes #36
- Closes #40 
- Closes #65
- Closes #66
- Closes #68
- Closes #69

## Summary

`crates.io` no longer renders the `[badges]` section of `Cargo.toml` on the crate page — the [manifest reference](https://doc.rust-lang.org/cargo/reference/manifest.html#the-badges-section) now says *"Packages should place badges in its README file which will be displayed on crates.io."*
`cargo-readme` is what bridges the two, so this PR fixes two long-standing badge bugs and closes two feature gaps to make that path solid.

Each commit is self-contained and builds/tests green on its own.

## Changes

- **fix: no more panic on missing attributes (`#36`).** Badge renderers indexed `attrs["repository"]` directly, aborting with an opaque `no entry found for key` panic when an attribute was missing. Renderers now return `Result` and report e.g. ``badge `coveralls` is missing required attribute `repository` ``.
- **fix: coveralls uses the configured branch (`#69`, supersedes `#68`).** The coverage image URL hard-coded `?branch=branch` instead of interpolating the branch.
- **feat: crates.io version badge (`#40`, supersedes `#66`).** New `crates-io` badge; `crate` defaults to the package name, so `crates-io = {}` is enough. This crate now dogfoods it via `[badges]` instead of a hard-coded line in `README.tpl`.
- **feat: discoverability (`#65`).** A `SUPPORTED_BADGES` catalog (single source of truth), a `cargo readme --list-badges` flag, and a "Badges" section in the crate docs.

## Testing

- `cargo test --all-features`, `cargo clippy --all-features --tests -- -D warnings`, `cargo fmt --check` all pass.
- New coverage: `badges-missing-attr` (error path, no panic), broadened `badges` fixture (crates-io, github, maintenance, coveralls branch), a `--list-badges` assertion, and a unit test guarding the catalog against drifting from the renderer.

## Notes

- Existing badge service URLs are left untouched; rewriting dead/legacy schemes (e.g. `travis-ci.org`) is intentionally out of scope.
- `github` and `crates-io` are `cargo-readme` extensions, not part of the official `[badges]` set — flagged as such in both `--list-badges` and the docs.