### PR TITLE
refactor: bundle generate_readme's boolean toggles into a ReadmeOptions struct

### DIFF
--- a/docs/uml/class.puml
+++ b/docs/uml/class.puml
@@ -1,3 +1,9 @@
+' STALE — kept for historical reasons, not accuracy.
+'
+' This diagram predates the current code and describes an aspirational design that was never
+' implemented (e.g. ConfigHelper, Renderer, a ReadmeConfig struct). The source code is the
+' specification: see src/readme/ and src/config/. Do not treat this file as authoritative.
+
 @startuml
 
 package std::iter {

--- a/docs/uml/sequence.puml
+++ b/docs/uml/sequence.puml
@@ -1,3 +1,9 @@
+' STALE — kept for historical reasons, not accuracy.
+'
+' This diagram predates the current code and describes an aspirational design that was never
+' implemented (e.g. ConfigHelper, Renderer, a ReadmeConfig struct). The source code is the
+' specification: see src/readme/ and src/config/. Do not treat this file as authoritative.
+
 @startuml flow
 
 actor User

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -190,3 +190,4 @@ pub use config::get_manifest;
 pub use config::project;
 pub use config::{supported_badges, BadgeInfo};
 pub use readme::generate_readme;
+pub use readme::ReadmeOptions;

--- a/src/main.rs
+++ b/src/main.rs
@@ -119,23 +119,17 @@ fn execute(args: &ReadmeArgs) -> Result<(), String> {
         helper::get_template_file(&project_root, args.template.as_deref())?
     };
 
-    let add_title = !args.no_title;
-    let add_badges = !args.no_badges;
-    let add_license = !args.no_license;
-    let indent_headings = !args.no_indent_headings;
-    let extract_from_comment = !args.no_comment_extraction;
+    let options = cargo_readme::ReadmeOptions {
+        add_title: !args.no_title,
+        add_badges: !args.no_badges,
+        add_license: !args.no_license,
+        indent_headings: !args.no_indent_headings,
+        extract_from_comment: !args.no_comment_extraction,
+    };
 
     // generate output
-    let readme = cargo_readme::generate_readme(
-        &project_root,
-        &mut source,
-        template_file.as_mut(),
-        add_title,
-        add_badges,
-        add_license,
-        indent_headings,
-        extract_from_comment,
-    )?;
+    let readme =
+        cargo_readme::generate_readme(&project_root, &mut source, template_file.as_mut(), options)?;
 
     helper::write_output(&mut dest, readme)
 }

--- a/src/readme/mod.rs
+++ b/src/readme/mod.rs
@@ -7,21 +7,46 @@ mod template;
 
 use crate::config;
 
+/// Toggles controlling how the README is generated.
+///
+/// Bundling these flags keeps `generate_readme` free of a long run of same-typed `bool`
+/// arguments, which are easy to transpose at the call site.
+#[derive(Debug, Clone, Copy)]
+pub struct ReadmeOptions {
+    /// Prepend the crate name as a title. Ignored when using a template.
+    pub add_title: bool,
+    /// Prepend the badges defined in `Cargo.toml`. Ignored when using a template.
+    pub add_badges: bool,
+    /// Append the license defined in `Cargo.toml`. Ignored when using a template.
+    pub add_license: bool,
+    /// Add an extra level to headings so the crate name can be the top heading.
+    pub indent_headings: bool,
+    /// Extract docs from comments rather than processing the input file as-is.
+    pub extract_from_comment: bool,
+}
+
+impl Default for ReadmeOptions {
+    fn default() -> Self {
+        ReadmeOptions {
+            add_title: true,
+            add_badges: true,
+            add_license: true,
+            indent_headings: true,
+            extract_from_comment: true,
+        }
+    }
+}
+
 /// Generates readme data from `source` file
 ///
 /// Optionally, a template can be used to render the output
-#[allow(clippy::too_many_arguments)]
 pub fn generate_readme<T: Read>(
     project_root: &Path,
     source: &mut T,
     template: Option<&mut T>,
-    add_title: bool,
-    add_badges: bool,
-    add_license: bool,
-    indent_headings: bool,
-    extract_from_comment: bool,
+    options: ReadmeOptions,
 ) -> Result<String, String> {
-    let lines = if extract_from_comment {
+    let lines = if options.extract_from_comment {
         extract::extract_docs(source).map_err(|e| format!("{}", e))?
     } else {
         BufReader::new(source)
@@ -30,7 +55,7 @@ pub fn generate_readme<T: Read>(
             .map_err(|e| format!("{}", e))?
     };
 
-    let readme = process::process_docs(lines, indent_headings).join("\n");
+    let readme = process::process_docs(lines, options.indent_headings).join("\n");
 
     // get template from file
     let template = if let Some(template) = template {
@@ -42,7 +67,7 @@ pub fn generate_readme<T: Read>(
     // get manifest from Cargo.toml
     let cargo = config::get_manifest(project_root)?;
 
-    template::render(template, readme, &cargo, add_title, add_badges, add_license)
+    template::render(template, readme, &cargo, options)
 }
 
 /// Load a template String from a file

--- a/src/readme/template.rs
+++ b/src/readme/template.rs
@@ -1,4 +1,5 @@
 use crate::config::Manifest;
+use crate::readme::ReadmeOptions;
 
 /// Renders the template
 ///
@@ -7,9 +8,7 @@ pub fn render(
     template: Option<String>,
     readme: String,
     cargo: &Manifest,
-    add_title: bool,
-    add_badges: bool,
-    add_license: bool,
+    options: ReadmeOptions,
 ) -> Result<String, String> {
     let title: &str = &cargo.name;
 
@@ -28,9 +27,9 @@ pub fn render(
             title,
             badges,
             license,
-            add_title,
-            add_badges,
-            add_license,
+            options.add_title,
+            options.add_badges,
+            options.add_license,
         )
     }
 }


### PR DESCRIPTION
- Closes #147
- Also flags the UML design docs stale — they proposed an unbuilt ReadmeConfig struct; source is now the spec