### PR TITLE
fix: resolve -i and -t relative to current working directory

### DIFF
--- a/src/helper.rs
+++ b/src/helper.rs
@@ -17,12 +17,13 @@ pub fn get_project_root(given_root: Option<&str>) -> Result<PathBuf, String> {
 }
 
 /// Get the source file from which the doc comments will be extracted
+///
+/// A given path is resolved from the current directory, like every other path on the command
+/// line; only the entrypoint fallback is looked up inside the project root.
 pub fn get_source(project_root: &Path, input: Option<&str>) -> Result<File, String> {
     match input {
         Some(input) => {
-            let input = project_root.join(input);
-            File::open(&input)
-                .map_err(|e| format!("Could not open file '{}': {}", input.to_string_lossy(), e))
+            File::open(input).map_err(|e| format!("Could not open file '{}': {}", input, e))
         }
         None => find_entrypoint(project_root),
     }
@@ -39,22 +40,18 @@ pub fn get_dest(output: Option<&str>) -> Result<Option<File>, String> {
 }
 
 /// Get the template file that will be used to render the output
+///
+/// A given path is resolved from the current directory; the default `README.tpl` is a project
+/// file, so it keeps being looked up next to `Cargo.toml`.
 pub fn get_template_file(
     project_root: &Path,
     template: Option<&str>,
 ) -> Result<Option<File>, String> {
     match template {
         // template path was given, try to read it
-        Some(template) => {
-            let template = project_root.join(template);
-            File::open(&template).map(Some).map_err(|e| {
-                format!(
-                    "Could not open template file '{}': {}",
-                    template.to_string_lossy(),
-                    e
-                )
-            })
-        }
+        Some(template) => File::open(template)
+            .map(Some)
+            .map_err(|e| format!("Could not open template file '{}': {}", template, e)),
         // try to read the default template file
         None => {
             let template = project_root.join(DEFAULT_TEMPLATE);

--- a/src/main.rs
+++ b/src/main.rs
@@ -75,14 +75,15 @@ struct ReadmeArgs {
     #[clap(long)]
     list_badges: bool,
 
-    /// File to read from.
+    /// File to read from, relative to the current directory.
     /// If not provided, will try to use `src/lib.rs`, then `src/main.rs`. If neither file
     /// could be found, will look into `Cargo.toml` for a `[lib]`, then for a single `[[bin]]`.
     /// If multiple binaries are found, an error will be returned.
     #[clap(long, short = 'i')]
     input: Option<String>,
 
-    /// File to write to. If not provided, will output to stdout.
+    /// File to write to, relative to the current directory.
+    /// If not provided, will output to stdout.
     #[clap(long, short = 'o')]
     output: Option<String>,
 
@@ -91,8 +92,8 @@ struct ReadmeArgs {
     #[clap(long = "project-root", short = 'r')]
     root: Option<String>,
 
-    /// Template used to render the output.
-    /// Default behavior is to use `README.tpl` if it exists.
+    /// Template used to render the output, relative to the current directory.
+    /// Default behavior is to use `README.tpl` from the project root if it exists.
     #[clap(long, short = 't')]
     template: Option<String>,
 }

--- a/tests/alternate-input.rs
+++ b/tests/alternate-input.rs
@@ -9,7 +9,7 @@ fn alternate_input_empty_docs() {
         "--no-template",
         "--no-badges",
         "--input",
-        "src/no_docs.rs",
+        "tests/test-project/src/no_docs.rs",
     ];
 
     Command::cargo_bin(env!("CARGO_PKG_NAME"))
@@ -29,7 +29,7 @@ fn alternate_input_single_line() {
         "--no-template",
         "--no-badges",
         "--input",
-        "src/single_line.rs",
+        "tests/test-project/src/single_line.rs",
     ];
 
     let expected = r#"# readme-test
@@ -56,7 +56,7 @@ fn alternate_input_a_little_bit_longer() {
         "--no-template",
         "--no-badges",
         "--input",
-        "src/other.rs",
+        "tests/test-project/src/other.rs",
     ];
 
     let expected = r#"# readme-test

--- a/tests/alternate-template.rs
+++ b/tests/alternate-template.rs
@@ -54,7 +54,7 @@ fn alternate_template() {
         "--project-root",
         "tests/test-project",
         "--template",
-        "NOTITLE.tpl",
+        "tests/test-project/NOTITLE.tpl",
     ];
 
     Command::cargo_bin(env!("CARGO_PKG_NAME"))

--- a/tests/multiline-doc.rs
+++ b/tests/multiline-doc.rs
@@ -56,7 +56,7 @@ fn multiline_doc() {
         "--project-root",
         "tests/test-project",
         "--input",
-        "src/multiline.rs",
+        "tests/test-project/src/multiline.rs",
     ];
 
     Command::cargo_bin(env!("CARGO_PKG_NAME"))

--- a/tests/no-comment-extraction.rs
+++ b/tests/no-comment-extraction.rs
@@ -11,7 +11,7 @@ fn markdown_input_without_flag_is_empty() {
         "--no-template",
         "--no-badges",
         "--input",
-        "README.rustdoc.md",
+        "tests/test-project/README.rustdoc.md",
     ];
 
     Command::cargo_bin(env!("CARGO_PKG_NAME"))
@@ -34,7 +34,7 @@ fn markdown_input_with_flag_is_processed() {
         "--no-badges",
         "--no-comment-extraction",
         "--input",
-        "README.rustdoc.md",
+        "tests/test-project/README.rustdoc.md",
     ];
 
     let expected = r#"# readme-test

--- a/tests/project-with-version.rs
+++ b/tests/project-with-version.rs
@@ -13,7 +13,7 @@ fn template_with_version() {
         "--project-root",
         "tests/project-with-version",
         "--template",
-        "README.tpl",
+        "tests/project-with-version/README.tpl",
     ];
 
     Command::cargo_bin(env!("CARGO_PKG_NAME"))

--- a/tests/relative-paths.rs
+++ b/tests/relative-paths.rs
@@ -1,0 +1,147 @@
+use assert_cmd::Command;
+use predicates::str::contains;
+use std::fs;
+use std::path::PathBuf;
+
+const TEMPLATE_EXPECTED: &str = r#"# readme-test
+
+Other readme template.
+
+Test crate for cargo-readme
+"#;
+
+#[test]
+fn input_is_relative_to_cwd() {
+    let args = [
+        "readme",
+        "--project-root",
+        "tests/test-project",
+        "--no-template",
+        "--no-badges",
+        "--input",
+        "tests/test-project/src/single_line.rs",
+    ];
+
+    let expected = r#"# readme-test
+
+Test crate for cargo-readme
+
+License: MIT
+"#;
+
+    Command::cargo_bin(env!("CARGO_PKG_NAME"))
+        .unwrap()
+        .args(args)
+        .assert()
+        .success()
+        .stdout(expected);
+}
+
+#[test]
+fn input_relative_to_project_root_is_not_found() {
+    let args = [
+        "readme",
+        "--project-root",
+        "tests/test-project",
+        "--no-template",
+        "--no-badges",
+        "--input",
+        "src/single_line.rs",
+    ];
+
+    Command::cargo_bin(env!("CARGO_PKG_NAME"))
+        .unwrap()
+        .args(args)
+        .assert()
+        .failure()
+        .stderr(contains("Could not open file 'src/single_line.rs'"));
+}
+
+#[test]
+fn template_is_relative_to_cwd() {
+    let args = [
+        "readme",
+        "--project-root",
+        "tests/test-project",
+        "--no-badges",
+        "--input",
+        "tests/test-project/src/single_line.rs",
+        "--template",
+        "tests/test-project/NOTITLE.tpl",
+    ];
+
+    Command::cargo_bin(env!("CARGO_PKG_NAME"))
+        .unwrap()
+        .args(args)
+        .assert()
+        .success()
+        .stdout(TEMPLATE_EXPECTED);
+}
+
+#[test]
+fn template_relative_to_project_root_is_not_found() {
+    let args = [
+        "readme",
+        "--project-root",
+        "tests/test-project",
+        "--no-badges",
+        "--template",
+        "NOTITLE.tpl",
+    ];
+
+    Command::cargo_bin(env!("CARGO_PKG_NAME"))
+        .unwrap()
+        .args(args)
+        .assert()
+        .failure()
+        .stderr(contains("Could not open template file 'NOTITLE.tpl'"));
+}
+
+/// The default template is looked up next to `Cargo.toml`, so `--project-root` stays its base.
+#[test]
+fn default_template_is_relative_to_project_root() {
+    let args = [
+        "readme",
+        "--project-root",
+        "tests/test-project",
+        "--no-badges",
+        "--input",
+        "tests/test-project/src/single_line.rs",
+    ];
+
+    Command::cargo_bin(env!("CARGO_PKG_NAME"))
+        .unwrap()
+        .args(args)
+        .assert()
+        .success()
+        .stdout(contains("Some text here"));
+}
+
+#[test]
+fn output_is_relative_to_cwd() {
+    let cwd = PathBuf::from(env!("CARGO_TARGET_TMPDIR")).join("output-is-relative-to-cwd");
+    fs::create_dir_all(&cwd).unwrap();
+    let written = cwd.join("README.md");
+    fs::remove_file(&written).ok();
+
+    let project_root = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("tests/test-project");
+    let args = [
+        "readme",
+        "--project-root",
+        project_root.to_str().unwrap(),
+        "--no-template",
+        "--no-badges",
+        "--output",
+        "README.md",
+    ];
+
+    Command::cargo_bin(env!("CARGO_PKG_NAME"))
+        .unwrap()
+        .current_dir(&cwd)
+        .args(args)
+        .assert()
+        .success();
+
+    assert!(written.is_file());
+    assert!(!project_root.join("README.md").exists());
+}

--- a/tests/workspace-inheritance.rs
+++ b/tests/workspace-inheritance.rs
@@ -27,7 +27,7 @@ fn workspace_inheritance_with_template() {
         "--project-root",
         "tests/workspace-inheritance/member",
         "--template",
-        "README.tpl",
+        "tests/workspace-inheritance/member/README.tpl",
     ];
 
     Command::cargo_bin(env!("CARGO_PKG_NAME"))


### PR DESCRIPTION
- Closes #30

#145 moved `-o` off `--project-root`.

`-i` and `-t` were left joined with it, so `cargo readme -r snax -t README.tpl` read `snax/README.tpl`, not `./README.tpl`.

- `--input` and `--template` now resolve from the current directory, like every other path argument
- The default `README.tpl` probe stays on the project root: it is a project file, not an argument

**This is a breaking change** for anyone passing `-i`/`-t` together with `-r`.

The workspace half of #30 (`Error: Missing [package] section in Cargo.toml` at a virtual manifest) is not addressed here.