### PR TITLE
feat(workspace): resolve a virtual manifest to its workspace member

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -94,6 +94,7 @@ dependencies = [
  "assert_cmd",
  "cargo_toml",
  "clap",
+ "glob",
  "percent-encoding",
  "predicates",
  "regex",
@@ -169,6 +170,12 @@ name = "equivalent"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
+
+[[package]]
+name = "glob"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e4eba85ea1d0a966a983acd07deee566e67395d2d96b6fb39e62b5a833f1eb0b"
 
 [[package]]
 name = "hashbrown"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,7 @@ rust-version = "1.80"
 [dependencies]
 cargo_toml = "1"
 clap = { version = "4", features = [ "derive" ] }
+glob = "0.3"
 toml = "1"
 regex = "1"
 serde = { version = "1", features = ["derive"] }

--- a/README.md
+++ b/README.md
@@ -186,6 +186,19 @@ Markdown as-is instead of scanning for doc comments, so a single source produces
 rendered crate docs and the repository `README.md`. Hidden doctest lines (starting with `# `)
 are still stripped, so examples stay runnable in `cargo test` yet read cleanly on GitHub.
 
+## Workspaces
+
+A README is generated for one package, so a workspace root with no `[package]` section has to
+be narrowed down to a member. If `[workspace]` names exactly one package, `cargo readme` uses
+it; otherwise it lists the members so you can pick one:
+
+```sh
+cargo readme --project-root crates/my-crate -o crates/my-crate/README.md
+```
+
+`default-members` takes precedence over `members` when both are set, matching how Cargo picks
+packages at a workspace root.
+
 ## License
 
 Licensed under either of

--- a/src/config/project.rs
+++ b/src/config/project.rs
@@ -29,7 +29,72 @@ pub fn get_root(given_root: Option<&str>) -> Result<PathBuf, String> {
         ));
     }
 
-    Ok(root)
+    resolve_virtual_manifest(root)
+}
+
+/// Point a virtual manifest at the package it unambiguously stands for
+///
+/// A workspace root without a `[package]` section documents nothing itself, so a README has to be
+/// generated for one of its members. Only a workspace naming exactly one package resolves without
+/// asking; anything else is a choice the caller has to make with `--project-root`.
+fn resolve_virtual_manifest(root: PathBuf) -> Result<PathBuf, String> {
+    let manifest = cargo_toml::Manifest::<toml::Value>::from_path(root.join("Cargo.toml"))
+        .map_err(|e| format!("Could not read Cargo.toml: {}", e))?;
+
+    if manifest.package.is_some() {
+        return Ok(root);
+    }
+
+    // Not a workspace either: leave the manifest to report its own missing `[package]`.
+    let Some(workspace) = manifest.workspace else {
+        return Ok(root);
+    };
+
+    let patterns = if workspace.default_members.is_empty() {
+        &workspace.members
+    } else {
+        &workspace.default_members
+    };
+
+    let mut members = Vec::new();
+    for pattern in patterns {
+        for member in expand_member(&root, pattern)? {
+            if !workspace.exclude.contains(&member) && !members.contains(&member) {
+                members.push(member);
+            }
+        }
+    }
+    members.sort();
+
+    match members.len() {
+        1 => Ok(root.join(&members[0])),
+        0 => Err("Cargo.toml is a virtual manifest with no workspace members".to_owned()),
+        _ => Err(format!(
+            "Multiple workspace members found, choose one with --project-root: [{}]",
+            members.join(", ")
+        )),
+    }
+}
+
+/// Expand one `[workspace] members` entry, which may be a glob, into the packages it names
+fn expand_member(root: &Path, pattern: &str) -> Result<Vec<String>, String> {
+    if !pattern.contains(['*', '?', '[']) {
+        return Ok(vec![pattern.to_owned()]);
+    }
+
+    let absolute = root.join(pattern);
+    let paths = glob::glob(&absolute.to_string_lossy())
+        .map_err(|e| format!("Invalid workspace member pattern '{}': {}", pattern, e))?;
+
+    Ok(paths
+        .filter_map(Result::ok)
+        .filter(|path| path.join("Cargo.toml").is_file())
+        .filter_map(|path| {
+            path.strip_prefix(root)
+                .ok()
+                .map(|rel| rel.to_string_lossy().replace('\\', "/"))
+        })
+        .collect())
 }
 
 /// Find the default entrypoiny to read the doc comments from

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -182,6 +182,19 @@
 //! Markdown as-is instead of scanning for doc comments, so a single source produces both the
 //! rendered crate docs and the repository `README.md`. Hidden doctest lines (starting with `# `)
 //! are still stripped, so examples stay runnable in `cargo test` yet read cleanly on GitHub.
+//!
+//! # Workspaces
+//!
+//! A README is generated for one package, so a workspace root with no `[package]` section has to
+//! be narrowed down to a member. If `[workspace]` names exactly one package, `cargo readme` uses
+//! it; otherwise it lists the members so you can pick one:
+//!
+//! ```sh
+//! cargo readme --project-root crates/my-crate -o crates/my-crate/README.md
+//! ```
+//!
+//! `default-members` takes precedence over `members` when both are set, matching how Cargo picks
+//! packages at a workspace root.
 
 mod config;
 mod readme;

--- a/tests/virtual-manifest.rs
+++ b/tests/virtual-manifest.rs
@@ -1,0 +1,70 @@
+use assert_cmd::Command;
+use predicates::str::contains;
+
+#[test]
+fn single_member_workspace_resolves_to_that_member() {
+    let args = [
+        "readme",
+        "--project-root",
+        "tests/virtual-manifest/single",
+        "--no-template",
+    ];
+
+    let expected = r#"# single-member
+
+The only package in this workspace.
+
+License: MIT
+"#;
+
+    Command::cargo_bin(env!("CARGO_PKG_NAME"))
+        .unwrap()
+        .args(args)
+        .assert()
+        .success()
+        .stdout(expected);
+}
+
+#[test]
+fn multi_member_workspace_lists_the_candidates() {
+    let args = [
+        "readme",
+        "--project-root",
+        "tests/virtual-manifest/multi",
+        "--no-template",
+    ];
+
+    Command::cargo_bin(env!("CARGO_PKG_NAME"))
+        .unwrap()
+        .args(args)
+        .assert()
+        .failure()
+        .stderr(contains(
+            "Multiple workspace members found, choose one with --project-root: \
+             [crates/alpha, crates/beta]",
+        ));
+}
+
+#[test]
+fn a_member_of_a_multi_member_workspace_still_works() {
+    let args = [
+        "readme",
+        "--project-root",
+        "tests/virtual-manifest/multi/crates/beta",
+        "--no-template",
+    ];
+
+    let expected = r#"# beta
+
+Docs for beta.
+
+License: MIT
+"#;
+
+    Command::cargo_bin(env!("CARGO_PKG_NAME"))
+        .unwrap()
+        .args(args)
+        .assert()
+        .success()
+        .stdout(expected);
+}

--- a/tests/virtual-manifest/multi/Cargo.toml
+++ b/tests/virtual-manifest/multi/Cargo.toml
@@ -1,0 +1,3 @@
+[workspace]
+resolver = "2"
+members = ["crates/*"]

--- a/tests/virtual-manifest/multi/crates/alpha/Cargo.toml
+++ b/tests/virtual-manifest/multi/crates/alpha/Cargo.toml
@@ -1,0 +1,4 @@
+[package]
+name = "alpha"
+version = "0.1.0"
+license = "MIT"

--- a/tests/virtual-manifest/multi/crates/alpha/src/lib.rs
+++ b/tests/virtual-manifest/multi/crates/alpha/src/lib.rs
@@ -1,0 +1,1 @@
+//! Docs for alpha.

--- a/tests/virtual-manifest/multi/crates/beta/Cargo.toml
+++ b/tests/virtual-manifest/multi/crates/beta/Cargo.toml
@@ -1,0 +1,4 @@
+[package]
+name = "beta"
+version = "0.1.0"
+license = "MIT"

--- a/tests/virtual-manifest/multi/crates/beta/src/lib.rs
+++ b/tests/virtual-manifest/multi/crates/beta/src/lib.rs
@@ -1,0 +1,1 @@
+//! Docs for beta.

--- a/tests/virtual-manifest/single/Cargo.toml
+++ b/tests/virtual-manifest/single/Cargo.toml
@@ -1,0 +1,3 @@
+[workspace]
+resolver = "2"
+members = ["member"]

--- a/tests/virtual-manifest/single/member/Cargo.toml
+++ b/tests/virtual-manifest/single/member/Cargo.toml
@@ -1,0 +1,4 @@
+[package]
+name = "single-member"
+version = "0.1.0"
+license = "MIT"

--- a/tests/virtual-manifest/single/member/src/lib.rs
+++ b/tests/virtual-manifest/single/member/src/lib.rs
@@ -1,0 +1,1 @@
+//! The only package in this workspace.


### PR DESCRIPTION
Running `cargo readme` at a workspace root failed with `Missing [package] section in Cargo.toml` — a section a virtual manifest cannot have. This is the workspace half of

- #30

which #152 addresses the path-resolution half of.

- A workspace naming exactly one package resolves to it silently
- More than one, and the error lists them: `Multiple workspace members found, choose one with --project-root: [crates/alpha, crates/beta]`
- `default-members` wins over `members`, as Cargo does when selecting at a root
- Glob members (`crates/*`) are expanded, hence the new `glob` dependency (no transitive deps)

It stops at one package rather than generating a README per member: the output is one stream and `-o` names one file.